### PR TITLE
[31] Move API Keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@
 # 	SMTP_USERNAME=username
 #	WEB_CONCURRENCY=1
 #	HONEYBADGER_API=[Honeybadger API Key]
+#	SKYLIGHT_API=[Silverlight API Key]

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,3 +1,3 @@
 ---
 # The authentication token for the application.
-authentication: YZEj-kZCMRN1D76cvpZ7hjwvKWByNR62woJiEnpBUQQ
+authentication: <%= ENV["SKYLIGHT_API"] %>


### PR DESCRIPTION
Resolves #31
	- Moves skylight api key into .env and puts entry into .env.example