### PR TITLE
[63] Fix order of resource before actions

### DIFF
--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Controller for Buildings
 class BuildingsController < ApplicationController
-  before_action :set_building, only: %i(show edit update destroy)
+  prepend_before_action :set_building, only: %i(show edit update destroy)
 
   def show
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Controller for Rooms
 class RoomsController < ApplicationController
-  before_action :set_room, only: [:show, :edit, :update, :destroy]
+  prepend_before_action :set_room, only: %i(show edit update destroy)
 
   def show
   end

--- a/app/controllers/suites_controller.rb
+++ b/app/controllers/suites_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Controller for Suites
 class SuitesController < ApplicationController
-  before_action :set_suite, only: %i(show edit update destroy)
+  prepend_before_action :set_suite, only: %i(show edit update destroy)
 
   def show
   end


### PR DESCRIPTION
Resolves #63
- Change `before_action` to `prepend_before_action` in facilities controllers (building, suite, and room). This ensures that the specific resources are loaded into the relevant instance variables before Pundit checks for authorization to interact with those records