### PR TITLE
[80] Add draw status page

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -4,6 +4,7 @@ class DrawsController < ApplicationController
   before_action :set_draw, only: [:show, :edit, :update, :destroy]
 
   def show
+    @intent_metrics = IntentMetricsQuery.call(@draw)
   end
 
   def new

--- a/app/queries/intent_metrics_query.rb
+++ b/app/queries/intent_metrics_query.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+#
+# Query to return the metrics on the intent selections of the students in a
+# specific draw.
+class IntentMetricsQuery
+  # This is used to allow us to execute this query with the default base
+  # relation without explicitly intantiating a new instance. It is often used to
+  # more easily use query objects as model scopes, e.g.
+  #   scope :intent_metrics, IntentMetricsQuery
+  # instead of
+  #   scope :intent_metrics, IntentMetricsQuery.new
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize an IntentMetricsQuery
+  #
+  # @param relation [User::ActiveRecord_Relation] the base relation for the
+  #   metrics query
+  def initialize(relation = User.all)
+    @relation = relation
+  end
+
+  # Execute the metrics query
+  #
+  # @param draw [Draw] the draw to collect metrics for
+  # @return [Hash{String => Integer}] a hash with intent Enum strings as keys
+  #   and associated record counts as values
+  def call(draw)
+    run_query(draw)
+    User.intents.map { |k, v| [k, metric_value(v)] }.to_h
+  end
+
+  private
+
+  def metric_value(enum_val)
+    @query_results.key?(enum_val) ? @query_results[enum_val] : 0
+  end
+
+  def run_query(draw)
+    @query_results = @relation.where(draw: draw).group(:intent).count
+  end
+end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -1,3 +1,16 @@
 <h1 class="draw-name"><%= @draw.name %></h1>
+<div class="intent-metrics">
+  <h2>Intent Metrics</h2>
+  <table>
+    <tbody>
+      <% @intent_metrics.each do |intent_value, count| %>
+        <tr>
+          <td class="metric-heading"><%= intent_value.humanize.capitalize %></td>
+          <td class="<%= intent_value %>-count"><%= count %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 <%= link_to 'Delete', draw_path(@draw), method: :delete %>
 

--- a/spec/features/draws/draw_status_spec.rb
+++ b/spec/features/draws/draw_status_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw status' do
+  let(:draw) { FactoryGirl.create(:draw) }
+
+  it 'displays intent metrics' do
+    metrics = { 'off_campus' => 0, 'on_campus' => 2, 'undeclared' => 1 }
+    create_intent_data(draw, metrics)
+
+    log_in(FactoryGirl.create(:user))
+    visit draw_path(draw)
+
+    expect(page_has_intent_metrics(page, metrics))
+  end
+
+  def create_intent_data(draw, metrics)
+    metrics.each do |status, count|
+      FactoryGirl.create_list(:user, count, draw: draw, intent: status)
+    end
+  end
+
+  def page_has_intent_metrics(page, metrics)
+    metrics.all? do |status, count|
+      page.has_css?(".#{status}-count", text: count.to_s)
+    end
+  end
+end

--- a/spec/queries/intent_metrics_query_spec.rb
+++ b/spec/queries/intent_metrics_query_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe IntentMetricsQuery do
+  let(:draw) { FactoryGirl.create(:draw) }
+
+  it 'returns a hash with metric values for all intent strings' do
+    expected = { 'off_campus' => 1, 'on_campus' => 2, 'undeclared' => 3 }
+    create_intent_data(draw, expected)
+
+    result = described_class.call(draw)
+
+    expect(result).to eq(expected)
+  end
+
+  it 'defaults to zero for intents with no students' do
+    expected = { 'off_campus' => 1, 'on_campus' => 0, 'undeclared' => 0 }
+    create_intent_data(draw, expected)
+
+    result = described_class.call(draw)
+
+    expect(result).to eq(expected)
+  end
+
+  it 'ignores students from other draws' do
+    FactoryGirl.create(:user, intent: 'off_campus')
+    expected = { 'off_campus' => 0, 'on_campus' => 0, 'undeclared' => 0 }
+
+    result = described_class.call(draw)
+
+    expect(result).to eq(expected)
+  end
+
+  def create_intent_data(draw, metrics)
+    metrics.each do |status, count|
+      FactoryGirl.create_list(:user, count, draw: draw, intent: status)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #80

In progress, will set up a status page for draws that link to intent reports where admins can update individual student intents. Currently just has a basic status spec.