### PR TITLE
[51] Add status enum to Draws with intent deadline

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+#
 # Controller for Draws
 class DrawsController < ApplicationController
-  before_action :set_draw, only: [:show, :edit, :update, :destroy]
+  prepend_before_action :set_draw, only: [:show, :edit, :update, :destroy,
+                                          :activate]
+  before_action :calculate_metrics, only: [:show, :activate]
 
-  def show
-    @intent_metrics = IntentMetricsQuery.call(@draw)
-  end
+  def show; end
 
   def new
     @draw = Draw.new
@@ -31,6 +32,11 @@ class DrawsController < ApplicationController
     handle_action(**result)
   end
 
+  def activate
+    result = DrawActivator.activate(draw: @draw)
+    handle_action(action: 'show', **result)
+  end
+
   private
 
   def authorize!
@@ -42,10 +48,15 @@ class DrawsController < ApplicationController
   end
 
   def draw_params
-    params.require(:draw).permit(:name, suite_ids: [], student_ids: [])
+    params.require(:draw).permit(:name, :intent_deadline, suite_ids: [],
+                                                          student_ids: [])
   end
 
   def set_draw
     @draw = Draw.find(params[:id])
+  end
+
+  def calculate_metrics
+    @intent_metrics = IntentMetricsQuery.call(@draw)
   end
 end

--- a/app/helpers/draws_helper.rb
+++ b/app/helpers/draws_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+#
+# Helper module for Draws
+module DrawsHelper
+  def intent_deadline_str(draw)
+    diff = (draw.intent_deadline - Time.zone.today).to_i
+    if diff.positive?
+      "The intent deadline is in #{day_str(diff)}."
+    elsif diff.negative?
+      "The intent deadline was #{day_str(diff.abs)} ago."
+    else
+      'The intent deadline is today.'
+    end
+  end
+
+  private
+
+  def day_str(n)
+    "#{n} #{'day'.pluralize(n)}"
+  end
+end

--- a/app/mailers/student_mailer.rb
+++ b/app/mailers/student_mailer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+#
+# Mailer class for user e-mails
+class StudentMailer < ApplicationMailer
+  default from: 'no-reply@vesta.app'
+
+  # Send initial invitation to students in a draw
+  #
+  # @attr user [User] the user to send the invitation to
+  def draw_invitation(user)
+    @user = user
+    @intent_deadline = user.draw.intent_deadline
+    @res_college = OpenStruct.new(name: 'College', dean: 'Dean Vesta',
+                                  vesta_url: 'https://vesta.app/',
+                                  admin_email: 'admin@vesta.app')
+    mail(to: @user.email, subject: 'The housing process has begun')
+  end
+end

--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -2,16 +2,47 @@
 #
 # Model to represent Housing Draws.
 #
-# @attr [String] name The name of the housing draw -- e.g. "Junior Draw 2016"
-# @attr [Array<User>] students The students in the draw.
-# @attr [Array<Suite>] suites The suites in the draw.
+# @attr name [String] The name of the housing draw -- e.g. "Junior Draw 2016"
+# @attr students [Array<User>] The students in the draw.
+# @attr suites [Array<Suite>] The suites in the draw.
+# @attr status [String] The status / phase of the draw (draft, pre_lottery,
+#   TODO: lottery, post_lottery). Note the use of underscores in the status
+#   strings; this prevents some unpleasantness with the helper methods.
 class Draw < ApplicationRecord
   has_many :students, class_name: 'User'
   has_and_belongs_to_many :suites # rubocop:disable Rails/HasAndBelongsToMany
 
   validates :name, presence: true
+  validates :status, presence: true
+
+  enum status: %w(draft pre_lottery)
 
   def suite_sizes
     suites.map(&:size).uniq
+  end
+
+  # Query method to see if a draw has at least one student.
+  #
+  # @return [Boolean] whether or not the draw has at least one student
+  def students?
+    student_count.positive?
+  end
+
+  # Query method to see if a draw has enough beds for its students.
+  #
+  # @return [Boolean] whether or not the draw has as many or more beds than it
+  #   has students
+  def enough_beds?
+    bed_count >= student_count
+  end
+
+  private
+
+  def student_count
+    @student_count ||= students.count
+  end
+
+  def bed_count
+    @bed_count ||= suites.sum(:size)
   end
 end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+#
 # Class for Draw permissions
 class DrawPolicy < ApplicationPolicy
   def show?
@@ -7,6 +8,10 @@ class DrawPolicy < ApplicationPolicy
 
   def update?
     user.rep? || user.admin?
+  end
+
+  def activate?
+    user.admin? && record.draft?
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/services/draw_activator.rb
+++ b/app/services/draw_activator.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+#
+# Service object to handle the activation of a draw. Checks to make sure the
+# draw has the correct status, updates the status, and sends e-mail invitations
+# to students in the draw.
+class DrawActivator
+  # Class method to permit calling :activate on the class without instantiating
+  # the service object directly
+  #
+  # @attr draw [Draw] the draw in question
+  def self.activate(draw:)
+    new(draw: draw).activate
+  end
+
+  # Initialize a new DrawActivator
+  #
+  # @attr draw [Draw] the draw in question
+  # @attr mailer [ActionMailer::Base] mailer class for sending invitation
+  #   e-mails
+  def initialize(draw:, mailer: StudentMailer)
+    @draw = draw
+    @errors = []
+    @mailer = mailer
+  end
+
+  # Activate a Draw
+  #
+  # @return [Hash{Symbol=>ApplicationRecord,Hash}] A results hash with the
+  #   message to set in the flash and either `nil` or the created object.
+  def activate
+    validate
+    activate_draw if currently_valid?
+    send_emails if currently_valid?
+    currently_valid? ? success : error
+  end
+
+  private
+
+  attr_accessor :draw, :errors, :mailer
+
+  def validate
+    errors << 'Draw must be a draft.' unless draw.draft?
+    errors << 'Draw must have at least one student.' unless draw.students?
+    return if draw.enough_beds?
+    errors << 'Draw must have at least one bed per student; you should add '\
+        'more suites or remove some students.'
+  end
+
+  def currently_valid?
+    errors.empty?
+  end
+
+  def activate_draw
+    return if draw.update(status: 'pre_lottery')
+    errors << 'Draw update failed.'
+  end
+
+  def send_emails
+    draw.students.each do |student|
+      mailer.draw_invitation(student).deliver_later
+    end
+  end
+
+  def success
+    { object: draw, msg: { notice: 'Draw successfully initiated.' } }
+  end
+
+  def error
+    {
+      object: nil,
+      msg: { error: "There was a problem initiating the draft:\n#{error_msgs}" }
+    }
+  end
+
+  def error_msgs
+    errors.join("\n")
+  end
+end

--- a/app/views/draws/_form.html.erb
+++ b/app/views/draws/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @draw do |f| %>
   <%= f.input :name %>
+  <%= f.input :intent_deadline %>
   <%= f.association :students, label_method: :name %>
   <%= f.association :suites, label_method: :number %>
   <%= f.submit %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -11,6 +11,12 @@
       <% end %>
     </tbody>
   </table>
+  <% if @draw.pre_lottery? && @draw.intent_deadline %>
+    <p><%= intent_deadline_str(@draw) %></p>
+  <% end %>
 </div>
+<% if policy(@draw).activate? %>
+  <%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %>
+<% end %>
 <%= link_to 'Delete', draw_path(@draw), method: :delete %>
 

--- a/app/views/student_mailer/draw_invitation.html.erb
+++ b/app/views/student_mailer/draw_invitation.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p>The housing process for <%= @res_college.name %> is now open. Please log in to <a href="<%= @res_college.vesta_url %>">Vesta</a> to indicate whether you'll be living on- or off-campus by <%= @intent_deadline %>. If you'll be living on-campus you'll be able to view available housing and form or join a housing group.</p>
+    <p>Please e-mail <%= @res_college.admin_email %> if you have any questions.</p>
+    <p>Sincerely,<br /><%= @res_college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/draw_invitation.text.erb
+++ b/app/views/student_mailer/draw_invitation.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @user.name %>,
+The housing process for <%= @res_college.name %> is now open. Please log in to <%= @res_college.vesta_url %> to indicate whether you'll be living on- or off-campus by <%= @intent_deadline %>. If you'll be living on-campus you'll be able to view available housing and form or join a housing group.
+Please e-mail <%= @res_college.admin_email %> if you have any questions.
+Sincerely,
+<%= @res_college.dean %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,9 @@ Rails.application.routes.draw do
   resources :users
   get 'users/:id/intent', to: 'users#edit_intent'
   put 'users/:id/intent', to: 'users#update_intent'
+
   resources :draws do
     resources :groups
   end
+  patch 'draws/:id/activate', to: 'draws#activate', as: 'activate_draw'
 end

--- a/db/migrate/20170106061203_add_status_to_draws.rb
+++ b/db/migrate/20170106061203_add_status_to_draws.rb
@@ -1,0 +1,5 @@
+class AddStatusToDraws < ActiveRecord::Migration[5.0]
+  def change
+    add_column :draws, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20170109220524_add_intent_deadline_to_draws.rb
+++ b/db/migrate/20170109220524_add_intent_deadline_to_draws.rb
@@ -1,0 +1,5 @@
+class AddIntentDeadlineToDraws < ActiveRecord::Migration[5.0]
+  def change
+    add_column :draws, :intent_deadline, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103034446) do
+ActiveRecord::Schema.define(version: 20170109220524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,8 +38,10 @@ ActiveRecord::Schema.define(version: 20170103034446) do
 
   create_table "draws", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "status",          default: 0, null: false
+    t.date     "intent_deadline"
   end
 
   create_table "draws_suites", id: false, force: :cascade do |t|

--- a/spec/features/draws/draw_start_spec.rb
+++ b/spec/features/draws/draw_start_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw activation' do
+  let(:draw) { FactoryGirl.create(:draw_with_members, status: 'draft') }
+  context 'as admin' do
+    before { log_in(FactoryGirl.create(:admin)) }
+
+    it 'can be initiated' do
+      visit draw_path(draw)
+      click_link('Begin draw process')
+      expect(page).to have_css('.flash-notice',
+                               text: 'Draw successfully initiated.')
+    end
+
+    it 'redirects on failure' do
+      draw = FactoryGirl.create(:draw, status: 'draft')
+      visit draw_path(draw)
+      click_link('Begin draw process')
+      expect(page).to have_css('.flash-error')
+    end
+  end
+
+  context 'as student' do
+    before { log_in(FactoryGirl.create(:student)) }
+
+    it 'cannot see the start button' do
+      visit draw_path(draw)
+      expect(page).not_to have_link('Begin draw process')
+    end
+  end
+end

--- a/spec/helpers/draws_helper_spec.rb
+++ b/spec/helpers/draws_helper_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawsHelper, type: :helper do
+  describe '#intent_deadline_str' do
+    it 'describes how many days until a future intent deadline' do
+      draw = instance_spy('draw', intent_deadline: Time.zone.today + 2.days)
+      expect(helper.intent_deadline_str(draw)).to \
+        eq('The intent deadline is in 2 days.')
+    end
+
+    it 'describes how many days since a past intent deadline' do
+      draw = instance_spy('draw', intent_deadline: Time.zone.today - 1.day)
+      expect(helper.intent_deadline_str(draw)).to \
+        eq('The intent deadline was 1 day ago.')
+    end
+
+    it 'describes when the intent deadline is today' do
+      draw = instance_spy('draw', intent_deadline: Time.zone.today)
+      expect(helper.intent_deadline_str(draw)).to \
+        eq('The intent deadline is today.')
+    end
+  end
+end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Draw, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to have_many(:students) }
     it { is_expected.to have_and_belong_to_many(:suites) }
+    it { is_expected.to validate_presence_of(:status) }
   end
 
   describe '#suite_sizes' do
@@ -14,6 +15,46 @@ RSpec.describe Draw, type: :model do
       draw = FactoryGirl.build_stubbed(:draw)
       allow(draw).to receive(:suites).and_return(suites)
       expect(draw.suite_sizes).to match_array([1, 2, 3])
+    end
+  end
+
+  # this is testing a private method, feel free to remove it if it ever fails
+  describe '#student_count' do
+    it 'returns the number of students in the draw' do
+      students = Array.new(3) { instance_spy('User') }
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:students).and_return(students)
+      expect(draw.send(:student_count)).to eq(3)
+    end
+  end
+
+  describe '#students?' do
+    it 'returns true if the student_count is greater than zero' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:student_count).and_return(1)
+      expect(draw.students?).to be_truthy
+    end
+
+    it 'returns false if the student_count is zero' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:student_count).and_return(0)
+      expect(draw.students?).to be_falsey
+    end
+  end
+
+  describe '#enough_beds?' do
+    it 'returns true if bed_count >= student_count' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:bed_count).and_return(2)
+      allow(draw).to receive(:student_count).and_return(1)
+      expect(draw.enough_beds?).to be_truthy
+    end
+
+    it 'returns false if bed_count < student_count' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:bed_count).and_return(1)
+      allow(draw).to receive(:student_count).and_return(2)
+      expect(draw.enough_beds?).to be_falsey
     end
   end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DrawPolicy do
     permissions :show? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :create?, :destroy?, :update? do
+    permissions :create?, :destroy?, :update?, :activate? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -23,7 +23,7 @@ RSpec.describe DrawPolicy do
     permissions :show?, :update? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :create?, :destroy? do
+    permissions :create?, :destroy?, :activate? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -38,6 +38,18 @@ RSpec.describe DrawPolicy do
     end
     permissions :index? do
       it { is_expected.to permit(user, Draw) }
+    end
+
+    permissions :activate? do
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
     end
   end
 end

--- a/spec/services/draw_activator_spec.rb
+++ b/spec/services/draw_activator_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe DrawActivator do
+  # we may want to extract this into a shared example if we use this pattern
+  # across all of our service objects
+  describe '.start' do
+    it 'calls :start on an instance of DrawStarter' do
+      draw = instance_spy('draw')
+      draw_activator = mock_draw_activator(draw: draw)
+      described_class.activate(draw: draw)
+      expect(draw_activator).to have_received(:activate)
+    end
+  end
+
+  describe '#activate' do
+    it 'checks to make sure that the draw is a draft' do
+      draw = instance_spy('draw', draft?: false)
+      result = described_class.activate(draw: draw)
+      expect(result[:msg][:error]).to include('Draw must be a draft.')
+    end
+
+    it 'checks to make sure that the draw has at least one student' do
+      draw = instance_spy('draw', students?: false)
+      result = described_class.activate(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('Draw must have at least one student.')
+    end
+
+    it 'checks to make sure that there are enough beds for students' do
+      draw = instance_spy('draw', enough_beds?: false)
+      result = described_class.activate(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('Draw must have at least one bed per student')
+    end
+
+    it 'updates the status of the draw to pre_lottery' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      described_class.activate(draw: draw)
+      expect(draw).to have_received(:update).with(status: 'pre_lottery')
+    end
+
+    it 'checks to see if the update works' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update).and_return(false)
+      result = described_class.activate(draw: draw)
+      expect(result[:msg][:error]).to include('Draw update failed.')
+    end
+
+    it 'sends invitations to the students in the draw' do
+      draw = valid_mock_draw_with_students(num_students: 2)
+      mailer = instance_spy('student_mailer')
+      described_class.new(draw: draw, mailer: mailer).activate
+      expect(mailer).to have_received(:draw_invitation).twice
+    end
+
+    it 'does not send emails if updating fails' do
+      draw = valid_mock_draw_with_students
+      allow(draw).to receive(:update).and_return(false)
+      mailer = instance_spy('student_mailer')
+      described_class.new(draw: draw, mailer: mailer).activate
+      expect(mailer).not_to have_received(:draw_invitation)
+    end
+
+    it 'returns the updated draw on success' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      result = described_class.activate(draw: draw)
+      expect(result[:object]).to eq(draw)
+    end
+
+    it 'sets the object key to nil in the hash on failure' do
+      draw = instance_spy('draw', validity_stubs(valid: false))
+      result = described_class.activate(draw: draw)
+      expect(result[:object]).to be_nil
+    end
+  end
+
+  def mock_draw_activator(param_hash)
+    instance_spy('draw_activator').tap do |draw_activator|
+      allow(described_class).to receive(:new).with(param_hash)
+        .and_return(draw_activator)
+    end
+  end
+
+  def valid_mock_draw_with_students(num_students: 2)
+    students = Array.new(num_students) { instance_spy('user') }
+    instance_spy('draw', validity_stubs(valid: true, students: students))
+  end
+
+  def validity_stubs(valid:, **attrs)
+    { draft?: valid, students?: valid, enough_beds?: valid }.merge(attrs)
+  end
+end


### PR DESCRIPTION
Resolves #51
- Add status enum to draws (current values 'draft' and 'pre-lottery', with 'lottery' and 'post-lottery' to be implemented in the future)
- Add button to initiate draw on draw show view with appropriate route
- Add DrawStarter to check validity of draw setup and handle transition to pre-lottery stage.