### PR TITLE
[24] Add CAS authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "2.3.1"
 gem "autoprefixer-rails"
 gem "delayed_job_active_record"
 gem 'devise', '~> 4.2.0'
+gem 'devise_cas_authenticatable', '~> 1.9.2'
 gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    devise_cas_authenticatable (1.9.2)
+      devise (>= 1.2.0)
+      rubycas-client (>= 2.2.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.1.1)
@@ -234,6 +237,8 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
+    rubycas-client (2.3.9)
+      activesupport
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)
@@ -318,6 +323,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   devise (~> 4.2.0)
+  devise_cas_authenticatable (~> 1.9.2)
   dotenv-rails
   factory_girl_rails
   ffaker (~> 2.4.0)

--- a/config/initializers/00_env_helper.rb
+++ b/config/initializers/00_env_helper.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+include EnvironmentHelper

--- a/config/initializers/0_devise.rb
+++ b/config/initializers/0_devise.rb
@@ -287,4 +287,56 @@ Devise.setup do |config|
   # When using OmniAuth, Devise cannot automatically set OmniAuth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
+  if env? 'CAS_BASE_URL'
+    config.cas_base_url = env('CAS_BASE_URL')
+
+    # you can override these if you need to, but cas_base_url is usually enough
+    # config.cas_login_url = "https://cas.myorganization.com/login"
+    # config.cas_logout_url = "https://cas.myorganization.com/logout"
+    # config.cas_validate_url = "https://cas.myorganization.com/serviceValidate"
+
+    # The CAS specification allows for the passing of a follow URL to be
+    # displayed when a user logs out on the CAS server. RubyCAS-Server also
+    # supports redirecting to a URL via the destination param. Set either of
+    # these urls and specify either nil, 'destination' or 'follow' as the
+    # logout_url_param. If the urls are blank but logout_url_param is set, a
+    # default will be detected for the service.
+    # config.cas_destination_url = 'https://cas.myorganization.com'
+    # config.cas_follow_url = 'https://cas.myorganization.com'
+    # config.cas_logout_url_param = nil
+
+    # You can specify the name of the destination argument with the following
+    # option. e.g. the following option will change it from 'destination' to
+    # 'url'
+    # config.cas_destination_logout_param_name = 'url'
+
+    # By default, devise_cas_authenticatable will create users.  If you would
+    # rather require user records to already exist locally before they can
+    # authenticate via CAS, uncomment the following line.
+    # config.cas_create_user = false
+
+    # You can enable Single Sign Out, which by default is disabled.
+    config.cas_enable_single_sign_out = true
+
+    # If you don't want to use the username returned from your CAS server as the
+    # unique identifier, but some other field passed in cas_extra_attributes,
+    # you can specify the field name here.
+    # config.cas_user_identifier = nil
+
+    # If you want to use the Devise Timeoutable module with single sign out,
+    # uncommenting this will redirect timeouts to the logout url, so that the
+    # CAS can take care of signing out the other serviced applocations. Note
+    # that each application manages timeouts independently, so one application
+    # timing out will kill the session on all applications serviced by the CAS.
+    # config.warden do |manager|
+    #   manager.failure_app =
+    #     DeviseCasAuthenticatable::SingleSignOut::WardenFailureApp
+    # end
+
+    # If you need to specify some extra configs for rubycas-client, you can do
+    # this via:
+    # config.cas_client_config_options = {
+    #     logger: Rails.logger
+    # }
+  end
 end

--- a/db/migrate/20170129191416_add_username_to_users.rb
+++ b/db/migrate/20170129191416_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :username, :string
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170120162744) do
+ActiveRecord::Schema.define(version: 20170129191416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,9 +110,11 @@ ActiveRecord::Schema.define(version: 20170120162744) do
     t.integer  "draw_id"
     t.integer  "intent",                 default: 0,  null: false
     t.integer  "gender",                 default: 0,  null: false
+    t.string   "username"
     t.index ["draw_id"], name: "index_users_on_draw_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+    t.index ["username"], name: "index_users_on_username", unique: true, using: :btree
   end
 
 end

--- a/lib/environment_helper.rb
+++ b/lib/environment_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+#
+# Helper methods for dealing with environment variables.
+module EnvironmentHelper
+  FALSE = [0, '0', false, 'false', nil, ''].freeze
+
+  # Check an environment variable for a 'falsey' value, as defined by the
+  # constant FALSE above.
+  #
+  # @return [Boolean] false if the environment variable constains a falsey
+  #   true otherwise
+  def env?(var)
+    !FALSE.include? ENV[var]
+  end
+
+  # Returns the value of an environment value, assuming it does not contain a
+  # falsey value as defined by constant FALSE above.
+  #
+  # @return [String, nil] the content of the environment variable if it does not
+  #   contain a falsey value, nil otherwise
+  def env(var)
+    return nil unless env?(var)
+    ENV[var]
+  end
+end

--- a/spec/lib/environment_helper_spec.rb
+++ b/spec/lib/environment_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'spec_helper'
+include EnvironmentHelper
+
+describe EnvironmentHelper do
+  FALSEY_VALUES = [0, '0', false, 'false', nil, ''].freeze
+
+  describe '.env?' do
+    FALSEY_VALUES.each do |val|
+      it "returns false if the variable is set to #{val}" do
+        set_env('VAR', val)
+        expect(env?('VAR')).to be_falsey
+      end
+    end
+
+    it 'returns true if the variable is set to any other value' do
+      set_env('VAR', 'foo')
+      expect(env?('VAR')).to be_truthy
+    end
+  end
+
+  describe '.env' do
+    FALSEY_VALUES.each do |val|
+      it "returns nil if the variable is set to #{val}" do
+        set_env('VAR', val)
+        expect(env('VAR')).to be_nil
+      end
+    end
+
+    it 'returns the variable if it is set to any other value' do
+      set_env('VAR', 'foo')
+      expect(env('VAR')).to eq('foo')
+    end
+  end
+
+  def set_env(variable, value)
+    allow(ENV).to receive(:[]).with(variable).and_return(value)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,6 +15,29 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_one(:group).through(:membership) }
   end
 
+  describe 'CAS username' do
+    context 'when CAS is used' do
+      subject(:user) { FactoryGirl.build(:user, username: 'foo') }
+      # rubocop:disable RSpec/AnyInstance
+      before do
+        allow_any_instance_of(User).to receive(:cas_auth?).and_return(true)
+      end
+      # rubocop:enable RSpec/AnyInstance
+      it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
+      it { is_expected.to validate_presence_of(:username) }
+
+      it 'downcases before saving' do
+        user.update(username: 'FOO')
+        expect(user.username).to eq('foo')
+      end
+    end
+
+    context 'when CAS is not used' do
+      subject { FactoryGirl.build(:user) }
+      it { is_expected.not_to validate_presence_of(:username) }
+    end
+  end
+
   # rubocop:disable RSpec/ExampleLength
   it 'destroys a dependent membership on destruction' do
     user = FactoryGirl.create(:student, intent: 'on_campus')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,11 @@ RSpec.configure do |config|
 
   # DatabaseCleaner set up
   config.use_transactional_fixtures = false
-  config.before(:suite) { DatabaseCleaner.clean_with(:deletion) }
+  config.before(:suite) do
+    # By default, do not use CAS in tests unless we specifically override ENV.
+    ENV.delete('CAS_BASE_URL')
+    DatabaseCleaner.clean_with(:deletion)
+  end
   config.before(:each) { DatabaseCleaner.strategy = :transaction }
   config.before(:each) { DatabaseCleaner.start }
   config.after(:each) { DatabaseCleaner.clean }


### PR DESCRIPTION
Resolves #24
- Add EnvironmentHelper module to make working with environment variables easier
- Add devise_cas_authenticatable gem
- Add username attribute to users, with validations dependent on whether or not CAS is used
- Ensure that the CAS_BASE_URL environment variable is not present by default during tests

Paired / reviewed by @esoterik 