### PR TITLE
[127] Add admin creation of users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,11 +5,25 @@ class UsersController < ApplicationController
   prepend_before_action :set_user, only: %i(show edit update edit_intent
                                             update_intent)
 
-  def show
+  def show; end
+
+  def build
+    @user = User.new
   end
 
-  def edit
+  def new
+    result = UserBuilder.build(id_attr: build_user_params['username'])
+    @user = result[:user]
+    handle_action(**result)
   end
+
+  def create
+    result = UserCreator.new(user_params).create!
+    @user = result[:object] ? result[:object] : User.new
+    handle_action(action: 'new', **result)
+  end
+
+  def edit; end
 
   def update
     result = Updater.new(object: @user, name_method: :name,
@@ -17,12 +31,7 @@ class UsersController < ApplicationController
     handle_action(action: 'edit', **result)
   end
 
-  def edit_intent
-  end
-
-  def update_intent
-    update
-  end
+  def edit_intent; end
 
   private
 
@@ -38,8 +47,12 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
   end
 
+  def build_user_params
+    params.require(:user).permit(:username)
+  end
+
   def user_params
     params.require(:user).permit(:first_name, :last_name, :role, :email,
-                                 :intent, :gender)
+                                 :intent, :gender, :username)
   end
 end

--- a/app/mailers/student_mailer.rb
+++ b/app/mailers/student_mailer.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 #
-# Mailer class for user e-mails
+# Mailer class for student e-mails
 class StudentMailer < ApplicationMailer
   default from: 'no-reply@vesta.app'
 
   # Send initial invitation to students in a draw
   #
-  # @attr user [User] the user to send the invitation to
+  # @param user [User] the user to send the invitation to
   def draw_invitation(user)
     @user = user
     @intent_deadline = user.draw.intent_deadline

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+#
+# Mailer class for general user e-mails
+class UserMailer < ApplicationMailer
+  default from: 'no-reply@versta.app'
+
+  # Send new account confirmation e-mail. Takes an auto-generated password as an
+  # optional parameter.
+  #
+  # @param user [User] the user to send the confirmation e-mail to
+  # @param password [String, nil] the auto-generated password, defaults to nil
+  def new_user_confirmation(user:, password: nil)
+    @user = user
+    @password = password
+    @res_college = OpenStruct.new(name: 'College', dean: 'Dean Vesta',
+                                  vesta_url: 'https://vesta.app/',
+                                  admin_email: 'admin@vesta.app')
+    mail(to: @user.email, subject: 'Welcome to Vesta')
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 # User model class for all user types.
 class User < ApplicationRecord
+  # Determine whether or not CAS authentication is being used, must be at the
+  # top of the class to be used in the Devise loading conditional below.
+  #
+  # @return [Boolean] true if the CAS_BASE_URL environment variable is set,
+  #   false otherwise
+  def self.cas_auth?
+    env? 'CAS_BASE_URL'
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  if env? 'CAS_BASE_URL'
+  if cas_auth?
     devise :cas_authenticatable, :trackable
   else
-    devise :database_authenticatable, :registerable,
-           :recoverable, :rememberable, :trackable, :validatable
+    devise :database_authenticatable, :recoverable, :rememberable, :trackable,
+           :validatable
   end
 
   belongs_to :draw
@@ -50,6 +59,6 @@ class User < ApplicationRecord
   end
 
   def cas_auth?
-    env? 'CAS_BASE_URL'
+    User.cas_auth?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -21,6 +21,10 @@ class UserPolicy < ApplicationPolicy
     show?
   end
 
+  def build?
+    new?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/services/creators/user_creator.rb
+++ b/app/services/creators/user_creator.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+#
+# Service object to create users.
+class UserCreator
+  # Allow for the calling of :create! on the parent class
+  def self.create!(params)
+    new(params).create!
+  end
+
+  # Initialize a UserCreator
+  #
+  # @param [ActionController::Parameters] params The params object from
+  #   the UsersController.
+  def initialize(params, mailer = UserMailer)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @mailer = mailer
+    @user = User.new(@params)
+    set_password unless cas_auth?
+  end
+
+  # Attempt to create a new user. If CAS auth is NOT enabled, autogenerates a
+  # password and sends it in the confirmation e-mail.
+  #
+  # @return [Hash{Symbol=>User,Hash}] a results hash with a message to set in
+  #   the flash, the user record (persisted or not), and either nil or the
+  #   record as the :object value
+  def create!
+    return error unless user.save
+    mailer.new_user_confirmation(user: user, password: password).deliver_later
+    success
+  end
+
+  private
+
+  attr_accessor :password, :user
+  attr_reader :mailer
+
+  def set_password
+    @password ||= Devise.friendly_token(12)
+    user.password = @password
+    user.password_confirmation = @password
+  end
+
+  def cas_auth?
+    User.cas_auth?
+  end
+
+  def success
+    {
+      object: user, user: user,
+      msg: { success: "User #{user.full_name} created." }
+    }
+  end
+
+  def error
+    errors = user.errors.full_messages
+    {
+      object: nil, user: user,
+      msg: { error: "Please review the errors below:\n#{errors.join("\n")}" }
+    }
+  end
+end

--- a/app/services/user_builder.rb
+++ b/app/services/user_builder.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Service object for building a user record for creation. Currently takes in a
+# username, ultimately will request data from IDR.
+class UserBuilder
+  # Allow for the calling of :build on the parent class
+  def self.build(id_attr:)
+    new(id_attr: id_attr).build
+  end
+
+  # Initialize a UserBuilder
+  #
+  # @param id_attr [String] the value for the ID attribute, either username
+  # (CAS) or e-mail (non-CAS)
+  def initialize(id_attr:)
+    @id_attr = id_attr
+    @user = User.new
+    @id_symbol = User.cas_auth? ? :username : :email
+  end
+
+  # Build a user record based on the given input, ensuring that it is unique
+  #
+  # @return [Hash{symbol=>User,Hash}] a results hash with a message to set in
+  #   the flash, nil as the :object value, the user record as the :user value,
+  #   and the :action to render. The :object is always set to nil so that
+  #   handle_action properly renders the template set in :action.
+  def build
+    return error unless unique?
+    assign_login
+    success
+  end
+
+  private
+
+  attr_accessor :user
+  attr_reader :id_attr, :id_symbol
+
+  def result_hash
+    { object: nil, user: user }
+  end
+
+  def success
+    result_hash.merge(action: 'new',
+                      msg: { success: 'Initialized user successfully' })
+  end
+
+  def error
+    result_hash.merge(action: 'build',
+                      msg: { error: 'User already exists' })
+  end
+
+  def unique?
+    @count ||= User.where(id_symbol => id_attr).count
+    @count.zero?
+  end
+
+  def assign_login
+    assign_method = "#{id_symbol}=".to_sym
+    user.send(assign_method, id_attr)
+  end
+end

--- a/app/views/draws/intent_report.html.erb
+++ b/app/views/draws/intent_report.html.erb
@@ -23,7 +23,7 @@
           <td data-role="student-last_name"><%= student.last_name %></td>
           <td data-role="student-first_name"><%= student.first_name %></td>
           <td data-role="student-intent"><%= student.intent %></td>
-          <td><%= link_to 'Edit intent', edit_user_intent_path(student) %></td>
+          <td><%= link_to 'Edit intent', edit_intent_user_path(student) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/user_mailer/new_user_confirmation.html.erb
+++ b/app/views/user_mailer/new_user_confirmation.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p>Welcome to Vesta! A new account has been created on your behalf and you can log in at <%= @res_college.vesta_url %> <% if @password %>with the following auto-generated password: <%= @password %>; you'll be able to change it after you log in.<% else %>via CAS.<% end %></p>
+    <p>Please e-mail <%= @res_college.admin_email %> if you have any questions.</p>
+    <p>Sincerely, <%= @res_college.dean %></p>
+  </body>
+</html>

--- a/app/views/user_mailer/new_user_confirmation.text.erb
+++ b/app/views/user_mailer/new_user_confirmation.text.erb
@@ -1,0 +1,4 @@
+Hi <%= @user.name %>, welcome to Vesta! A new account has been created on your behalf and you can log in at <%= @res_college.vesta_url %> <% if @password %>with the following auto-generated password: <%= @password %>; you'll be able to change it after you log in.<% else %>via CAS.<% end %>
+Please e-mail <%= @res_college.admin_email %> if you have any questions.
+Sincerely,
+<%= @res_college.dean %>

--- a/app/views/users/build.html.erb
+++ b/app/views/users/build.html.erb
@@ -1,0 +1,5 @@
+<h1>Add new user</h1>
+<%= simple_form_for @user, url: new_user_path, method: :get do |f| %>
+  <%= f.input :username %>
+  <%= f.submit 'Continue' %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,14 @@
+<h1>Add new user</h1>
+<%= simple_form_for @user do |f| %>
+  <%= f.input :email, disabled: !@user.email.empty? %>
+  <%= f.input(:email, as: :hidden) unless @user.email.empty? %>
+  <% unless @user.try(:username).try(:empty?) %>
+    <%= f.input :username, disabled: true %>
+    <%= f.input :username, as: :hidden %>
+  <% end %>
+  <%= f.input :first_name %>
+  <%= f.input :last_name %>
+  <%= f.input :role, collection: User.roles.keys %>
+  <%= f.input :gender, collection: User.genders.keys %>
+  <%= f.submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
   resources :buildings
   resources :suites
   resources :rooms
+  get 'users/build', to: 'users#build', as: 'build_user'
   resources :users
-  get 'users/:id/intent', to: 'users#edit_intent', as: 'edit_user_intent'
-  put 'users/:id/intent', to: 'users#update_intent'
+  get 'users/:id/intent', to: 'users#edit_intent', as: 'edit_intent_user'
 
   resources :draws do
     resources :groups do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,13 @@
 
 puts 'Generating seed data....'
 
-Generator.generate_admin(email: 'email@email.com', password: 'passw0rd')
+if User.cas_auth?
+  puts 'Please enter your CAS login: '
+  cas_login = $stdin.gets.chomp
+  Generator.generate_admin(username: cas_login)
+else
+  Generator.generate_admin(email: 'email@email.com', password: 'passw0rd')
+end
 Generator.generate(model: 'building', count: 2)
 Generator.generate(model: 'suite', count: 15)
 

--- a/lib/seed/user_generator.rb
+++ b/lib/seed/user_generator.rb
@@ -11,6 +11,7 @@ class UserGenerator
 
   def initialize(overrides: {})
     gen_params(overrides: overrides)
+    @params.delete(:password) if User.cas_auth?
   end
 
   def generate

--- a/spec/features/draws/draw_intent_report_spec.rb
+++ b/spec/features/draws/draw_intent_report_spec.rb
@@ -85,6 +85,6 @@ RSpec.feature 'Draw intent report' do
 
   def page_has_intent_update_link(page, student)
     page.assert_selector(:link, 'Edit intent',
-                         href: edit_user_intent_path(student))
+                         href: edit_intent_user_path(student))
   end
 end

--- a/spec/features/users/admin_creation_spec.rb
+++ b/spec/features/users/admin_creation_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Admin creation' do
+  before { log_in FactoryGirl.create(:admin) }
+  it 'can be performed by other admins' do
+    visit build_user_path
+    submit_username('foo@example.com')
+    submit_profile_data(first_name: 'John', last_name: 'Smith', role: 'admin',
+                        gender: 'male')
+    expect(page).to have_content('User John Smith created.')
+  end
+
+  def submit_username(username)
+    fill_in 'user_username', with: username
+    click_on 'Continue'
+  end
+
+  def submit_profile_data(first_name:, last_name:, role:, gender:)
+    fill_in 'user_first_name', with: first_name
+    fill_in 'user_last_name', with: last_name
+    select gender, from: 'user_gender'
+    select role, from: 'user_role'
+    click_on 'Create'
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,11 +18,7 @@ RSpec.describe User, type: :model do
   describe 'CAS username' do
     context 'when CAS is used' do
       subject(:user) { FactoryGirl.build(:user, username: 'foo') }
-      # rubocop:disable RSpec/AnyInstance
-      before do
-        allow_any_instance_of(User).to receive(:cas_auth?).and_return(true)
-      end
-      # rubocop:enable RSpec/AnyInstance
+      before { allow(User).to receive(:cas_auth?).and_return(true) }
       it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
       it { is_expected.to validate_presence_of(:username) }
 
@@ -48,6 +44,17 @@ RSpec.describe User, type: :model do
       raise_error(ActiveRecord::RecordNotFound)
   end
   # rubocop:enable RSpec/ExampleLength
+
+  describe '.cas_auth?' do
+    it 'returns true if the CAS_BASE_URL env variable is set' do
+      allow(User).to receive(:env?).with('CAS_BASE_URL').and_return(true)
+      expect(User.cas_auth?).to be_truthy
+    end
+    it 'returns false if the CAS_BASE_URL env variable is not set' do
+      allow(User).to receive(:env?).with('CAS_BASE_URL').and_return(false)
+      expect(User.cas_auth?).to be_falsey
+    end
+  end
 
   describe '#name' do
     it 'is the first name' do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UserPolicy do
                 :edit_intent?, :update_intent? do
       it { is_expected.not_to permit(user, other_user) }
     end
-    permissions :index? do
+    permissions :index?, :build? do
       it { is_expected.not_to permit(user, User) }
     end
   end
@@ -28,7 +28,7 @@ RSpec.describe UserPolicy do
                 :edit_intent?, :update_intent? do
       it { is_expected.not_to permit(user, other_user) }
     end
-    permissions :index? do
+    permissions :index?, :build? do
       it { is_expected.not_to permit(user, User) }
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe UserPolicy do
                 :edit_intent?, :update_intent? do
       it { is_expected.to permit(user, other_user) }
     end
-    permissions :index? do
+    permissions :index?, :build? do
       it { is_expected.to permit(user, User) }
     end
   end

--- a/spec/services/creators/user_creator_spec.rb
+++ b/spec/services/creators/user_creator_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UserCreator do
+  describe '.create!' do
+    it 'calls :create! on an instance of UserCreator' do
+      params = instance_spy('Hash')
+      user_creator = mock_user_creator(params)
+      described_class.create!(params)
+      expect(user_creator).to have_received(:create!)
+    end
+  end
+
+  describe '#create!' do
+    context 'success' do
+      it 'returns a valid user' do
+        params = instance_spy('ActionController::Parameters',
+                              to_h: valid_params)
+        result = described_class.create!(params)
+        expect(result[:object]).to be_an_instance_of(User)
+      end
+      it 'returns a success message' do
+        params = instance_spy('ActionController::Parameters',
+                              to_h: valid_params)
+        result = described_class.create!(params)
+        expect(result[:msg]).to have_key(:success)
+      end
+      it 'sends a confirmation e-mail' do
+        params = instance_spy('ActionController::Parameters',
+                              to_h: valid_params)
+        mailer = instance_spy('user_mailer')
+        described_class.new(params, mailer).create!
+        expect(mailer).to have_received(:new_user_confirmation)
+      end
+
+      context 'without CAS' do # rubocop:disable RSpec/NestedGroups
+        before { allow(User).to receive(:cas_auth?).and_return(false) }
+        it 'assigns a random password to the user' do
+          params = instance_spy('ActionController::Parameters',
+                                to_h: valid_params)
+          result = described_class.create!(params)
+          expect(result[:object].password).not_to be_empty
+        end
+      end
+      # 2017/01/29: this test currently fails because stubbing out
+      # User.cas_auth? doesn't change how the User class was loaded (without
+      # CAS), and so it's still running password validations. Even switching to
+      # any_instance_of doesn't help because it has to do with when Rails loads
+      # the User class, and same goes with using an ENV wrapper as we did in
+      # Reservations. Leaving it pending for now.
+      context 'with CAS' do # rubocop:disable RSpec/NestedGroups
+        before { allow(User).to receive(:cas_auth?).and_return(true) }
+        xit 'does not assign a password to the user' do
+          params = instance_spy('ActionController::Parameters',
+                                to_h: valid_params)
+          result = described_class.create!(params)
+          expect(result[:object].password).to be_empty
+        end
+      end
+    end
+
+    context 'failure' do
+      it 'returns the invalid user' do
+        params = instance_spy('ActionController::Parameters', to_h: {})
+        result = described_class.create!(params)
+        expect(result[:object]).to be_nil
+      end
+      it 'returns an error message' do
+        params = instance_spy('ActionController::Parameters', to_h: {})
+        result = described_class.create!(params)
+        expect(result[:msg]).to have_key(:error)
+      end
+      it 'does not send a confirmation e-mail' do
+        params = instance_spy('ActionController::Parameters', to_h: {})
+        mailer = instance_spy('UserMailer')
+        described_class.new(params, mailer).create!
+        expect(mailer).not_to have_received(:new_user_confirmation)
+      end
+    end
+  end
+
+  def mock_user_creator(params)
+    instance_spy('UserCreator').tap do |user_creator|
+      allow(UserCreator).to receive(:new).with(params).and_return(user_creator)
+    end
+  end
+
+  def valid_params
+    {
+      first_name: 'John', last_name: 'Smith', gender: 'male', role: 'admin',
+      email: 'john@smith.com', username: 'foo'
+    }
+  end
+end

--- a/spec/services/user_builder_spec.rb
+++ b/spec/services/user_builder_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UserBuilder do
+  describe '.build' do
+    it 'calls :build on an instance of UserBuilder' do
+      user_builder = mock_user_builder(id_attr: 'foo')
+      described_class.build(id_attr: 'foo')
+      expect(user_builder).to have_received(:build)
+    end
+  end
+
+  describe '#build' do
+    context 'success' do
+      it 'returns instance of User class' do
+        result = described_class.build(id_attr: 'foo')
+        expect(result[:user]).to be_instance_of(User)
+      end
+      it 'returns unpersisted record' do
+        result = described_class.build(id_attr: 'foo')
+        expect(result[:user].persisted?).to be_falsey
+      end
+      it 'returns a success flash' do
+        result = described_class.build(id_attr: 'foo')
+        expect(result[:msg]).to have_key(:success)
+      end
+      it 'returns action: new' do
+        result = described_class.build(id_attr: 'foo')
+        expect(result[:action]).to eq('new')
+      end
+      context 'with CAS' do # rubocop:disable RSpec/NestedGroups
+        before { allow(User).to receive(:cas_auth?).and_return(true) }
+        it 'sets the username to the username' do
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:user].username).to eq('foo')
+        end
+        it 'does not set the email' do
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:user].email).to be_empty
+        end
+      end
+      context 'without CAS' do # rubocop:disable RSpec/NestedGroups
+        it 'sets the email to the username' do
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:user].email).to eq('foo')
+        end
+      end
+    end
+
+    context 'failure' do
+      context 'without CAS, taken email' do # rubocop:disable RSpec/NestedGroups
+        it 'returns new instance of User' do
+          allow(User).to receive(:where).with(email: 'foo')
+            .and_return(instance_spy('ActiveRecord::Relation', count: 1))
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:user].attributes).to eq(User.new.attributes)
+        end
+        it 'returns an error flash' do
+          allow(User).to receive(:where).with(email: 'foo')
+            .and_return(instance_spy('ActiveRecord::Relation', count: 1))
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:msg]).to have_key(:error)
+        end
+        it 'returns action: build' do
+          allow(User).to receive(:where).with(email: 'foo')
+            .and_return(instance_spy('ActiveRecord::Relation', count: 1))
+          result = described_class.build(id_attr: 'foo')
+          expect(result[:action]).to eq('build')
+        end
+      end
+    end
+  end
+
+  def mock_user_builder(params_hash)
+    instance_spy('UserBuilder').tap do |user_builder|
+      allow(UserBuilder).to receive(:new).with(params_hash)
+        .and_return(user_builder)
+    end
+  end
+end

--- a/spec/views/user_mailer/new_user_confirmation.html.erb_spec.rb
+++ b/spec/views/user_mailer/new_user_confirmation.html.erb_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'user_mailer/new_user_confirmation.html.erb' do
+  before { mock_assigns }
+  context 'with password set' do
+    before { assign(:password, 'foo') }
+
+    it 'displays information about the password' do
+      render
+      expect(rendered).to match(/password/)
+    end
+    it 'does not display CAS info' do
+      render
+      expect(rendered).not_to match(/CAS/)
+    end
+  end
+
+  context 'with no password set' do
+    before { assign(:password, nil) }
+
+    it 'displays information about CAS' do
+      render
+      expect(rendered).to match(/CAS/)
+    end
+    it 'does not display password info' do
+      render
+      expect(rendered).not_to match(/password/)
+    end
+  end
+
+  def mock_assigns
+    assign(:user, FactoryGirl.build_stubbed(:user))
+    assign(:res_college, OpenStruct.new(name: 'Foo', dean: 'Foo',
+                                        vesta_url: 'Foo', admin_email: 'Foo'))
+  end
+end


### PR DESCRIPTION
Resolves #127
- Add two-step user creation process, first a build step where either a username or email (CAS or non-CAS) is passed in and checked for uniqueness, after which the rest of the profile data is created and passed to a more standard Creator-type service object
- Add UserMailer with account confirmation e-mail that optionally includes an auto-generated password for non-CAS auth