### PR TITLE
[129] Add web service lookup of user profile data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.5.1)
@@ -122,7 +123,7 @@ GEM
       sprockets-es6 (>= 0.9.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
-    hashdiff (0.3.0)
+    hashdiff (0.3.2)
     high_voltage (3.0.0)
     honeybadger (2.6.1)
     i18n (0.7.0)
@@ -165,6 +166,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    public_suffix (2.0.5)
     puma (3.6.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
@@ -299,7 +301,7 @@ GEM
       activemodel (>= 5.0)
       debug_inspector
       railties (>= 5.0)
-    webmock (2.1.0)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -371,4 +373,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,7 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:first_name, :last_name, :role, :email,
-                                 :intent, :gender, :username)
+                                 :intent, :gender, :username, :class_year,
+                                 :college)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+#
+# Helper methods for the Users views
+module UsersHelper
+  # Generate a form field for a profile attribute. Should be disabled if the
+  # attribute is defined on the passed user object, and should include a hidden
+  # field if disabled.
+  #
+  # @param form [SimpleForm::FormBuilder] the form object
+  # @param user [User] the user record
+  # @param field [Symbol] the field / attribute
+  # @return [String] the form field, optionally disabled with a hidden field for
+  #   the form to submit data
+  def profile_field(form:, user:, field:)
+    if user.send(field).try(:empty?) || user.send(field).nil?
+      form.input(field, disabled: false)
+    else
+      form.input(field, disabled: true) + "\n" +
+        form.input(field, as: :hidden)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
-# User model class for all user types.
+#
+# User model class for all user types. Optionally loads in sets of Devise
+# modules for authentication. Validates presence of required profile fields
+# (noted below).
+#
+# @attr email [String] the user's e-mail (required for database auth)
+# @attr encrypted_password [String] the encrypted password for database
+#   authentication (handled by Devise)
+# @attr username [String] the user's CAS login (required for CAS auth)
+# @attr role [Integer] an enum for the user's role, admin, [housing] rep, or
+#   student (required)
+# @attr first_name [String] the user's first name (required)
+# @attr last_name [String] the user's last name (required)
+# @attr intent [Integer] an enum for the user's housing intent, on_campus,
+#   off_campus, or undeclared (required)
+# @attr gender [Integer] an enum for the user's gender, male, female, or
+#   undeclared (required)
+# @attr class_year [Integer] the graduating class year of the student (optional)
+# @attr college [String] a string describing the residential college to which
+#   the user belongs (optional)
 class User < ApplicationRecord
   # Determine whether or not CAS authentication is being used, must be at the
   # top of the class to be used in the Devise loading conditional below.

--- a/app/services/idr_profile_querier.rb
+++ b/app/services/idr_profile_querier.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+require 'open-uri'
+
+# Service object to query the Yale IDR web service (or one similar to it) for
+# profile data. Expects an XML response, meant to be as general as possible.
+class IDRProfileQuerier
+  # Allows for :query to be called on the class itself
+  def self.query(**params)
+    new(**params).query
+  end
+
+  # Initialize a ProfileRequester
+  #
+  # @param id [String] the id attribute to query the web service with
+  def initialize(id:)
+    @id = id
+    @attr_hash = {}
+  end
+
+  # Requests user profile data from a web service
+  #
+  # @return [Hash{Symbol=>String},nil] either returns a hash with profile
+  #   attributes that can be used to assign_attributes on a user record or nil
+  #   if the lookup failed
+  def query
+    return attr_hash unless all_config_params_defined?
+    build_request
+    issue_request
+    parse_results
+    attr_hash
+  end
+
+  private
+
+  attr_accessor :attr_hash
+  attr_reader :id, :response, :uri, :http_request
+
+  CONFIG_PARAM_HEADER = 'PROFILE_REQUEST_'
+  PROFILE_FIELDS =
+    %i(first_name last_name email gender class_year college).freeze
+  REQUIRED_CONFIG_PARAMS =
+    (%w(URL QUERY_PARAM) + PROFILE_FIELDS.map { |f| f.to_s.upcase }).freeze
+
+  def all_config_params_defined?
+    required_config_params.all? { |param| env?(param) }
+  end
+
+  def required_config_params
+    REQUIRED_CONFIG_PARAMS.map { |param| CONFIG_PARAM_HEADER + param }
+  end
+
+  def build_request
+    @uri ||= URI(url_str)
+    @http_request ||= Net::HTTP::Get.new(uri)
+    @http_request.basic_auth(username, password) if basic_auth?
+  end
+
+  def url_str
+    env(config_var('URL')) + '?' + env(config_var('QUERY_PARAM')) + "=#{id}"
+  end
+
+  def basic_auth?
+    env?(config_var('USERNAME')) && env?(config_var('PASSWORD'))
+  end
+
+  def config_var(param)
+    CONFIG_PARAM_HEADER + param
+  end
+
+  def username
+    env(config_var('USERNAME'))
+  end
+
+  def password
+    env(config_var('PASSWORD'))
+  end
+
+  def issue_request
+    @response ||= Net::HTTP.start(uri.hostname, uri.port,
+                                  use_ssl: use_ssl?) do |http|
+      http.request(http_request)
+    end
+  end
+
+  def use_ssl?
+    !url_str.match(/https/).nil?
+  end
+
+  def parse_results
+    xml = Nokogiri::XML(response.body)
+    PROFILE_FIELDS.each do |field|
+      attr_hash.store(field, extract_data(xml, field))
+    end
+    map_gender_to_enum_vals
+  end
+
+  def extract_data(xml, field_key)
+    tag = env(config_var(field_key.to_s.upcase))
+    xml.at_xpath("//#{tag}").try(:content)
+  end
+
+  def map_gender_to_enum_vals
+    gender_map = { 'F' => 'female', 'M' => 'male', 'N' => 'undeclared',
+                   'NULL' => 'undeclared' }
+    attr_hash[:gender] = gender_map[attr_hash[:gender]]
+  end
+end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,13 +1,14 @@
 <h1>Add new user</h1>
 <%= simple_form_for @user do |f| %>
-  <%= f.input :email, disabled: !@user.email.empty? %>
-  <%= f.input(:email, as: :hidden) unless @user.email.empty? %>
+  <%= profile_field(form: f, user: @user, field: :email) %>
   <% unless @user.try(:username).try(:empty?) %>
     <%= f.input :username, disabled: true %>
     <%= f.input :username, as: :hidden %>
   <% end %>
-  <%= f.input :first_name %>
-  <%= f.input :last_name %>
+  <%= profile_field(form: f, user: @user, field: :first_name) %>
+  <%= profile_field(form: f, user: @user, field: :last_name) %>
+  <%= profile_field(form: f, user: @user, field: :class_year) %>
+  <%= profile_field(form: f, user: @user, field: :college) %>
   <%= f.input :role, collection: User.roles.keys %>
   <%= f.input :gender, collection: User.genders.keys %>
   <%= f.submit %>

--- a/db/migrate/20170201052315_add_idr_fields_to_users.rb
+++ b/db/migrate/20170201052315_add_idr_fields_to_users.rb
@@ -1,0 +1,8 @@
+class AddIdrFieldsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    change_table :users do |t|
+      t.integer :class_year
+      t.string :college
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170129191416) do
+ActiveRecord::Schema.define(version: 20170201052315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,8 @@ ActiveRecord::Schema.define(version: 20170129191416) do
     t.integer  "intent",                 default: 0,  null: false
     t.integer  "gender",                 default: 0,  null: false
     t.string   "username"
+    t.integer  "class_year"
+    t.string   "college"
     t.index ["draw_id"], name: "index_users_on_draw_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/lib/seed/user_generator.rb
+++ b/lib/seed/user_generator.rb
@@ -30,6 +30,16 @@ class UserGenerator
                   gender: User.genders.keys.sample,
                   role: 'student',
                   intent: User.intents.keys.sample,
-                  password: 'passw0rd' }.merge(overrides)
+                  password: 'passw0rd',
+                  class_year: random_class_year,
+                  college: random_college_str }.merge(overrides)
+  end
+
+  def random_class_year
+    Time.zone.today.year + (1..3).to_a.sample
+  end
+
+  def random_college_str
+    ('A'..'Z').to_a.sample(2).join
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'simple_form'
+
+RSpec.describe UsersHelper, type: :helper do
+  describe '#profile_field' do
+    it 'returns an enabled field if the attribute is missing' do
+      u = FactoryGirl.build_stubbed(:user, first_name: nil, id: 123)
+      helper.simple_form_for u do |f|
+        expect(helper.profile_field(form: f, user: u, field: :first_name)).to \
+          eq(f.input(:first_name, disabled: false))
+      end
+    end
+    it 'returns an enabled field if the attribute is empty' do
+      u = FactoryGirl.build_stubbed(:user, first_name: '', id: 123)
+      helper.simple_form_for u do |f|
+        expect(helper.profile_field(form: f, user: u, field: :first_name)).to \
+          eq(f.input(:first_name, disabled: false))
+      end
+    end
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns a disabled and a hidden field if the attribute is populated' do
+      u = FactoryGirl.build_stubbed(:user, first_name: 'John', id: 123)
+      helper.simple_form_for u do |f|
+        expect(helper.profile_field(form: f, user: u, field: :first_name)).to \
+          eq(f.input(:first_name, disabled: true) + "\n" +
+             f.input(:first_name, as: :hidden))
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     # By default, do not use CAS in tests unless we specifically override ENV.
     ENV.delete('CAS_BASE_URL')
+    # Remove all PROFILE_REQUESTER keys from ENV to avoid issuing requests
+    ENV.delete_if { |k, _v| !k.match(/PROFILE_REQUEST_/).nil? }
     DatabaseCleaner.clean_with(:deletion)
   end
   config.before(:each) { DatabaseCleaner.strategy = :transaction }

--- a/spec/services/idr_profile_querier_spec.rb
+++ b/spec/services/idr_profile_querier_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+REQUIRED_CONFIG_PARAMS =
+  %w(PROFILE_REQUEST_URL PROFILE_REQUEST_QUERY_PARAM PROFILE_REQUEST_FIRST_NAME
+     PROFILE_REQUEST_LAST_NAME PROFILE_REQUEST_EMAIL PROFILE_REQUEST_GENDER
+     PROFILE_REQUEST_CLASS_YEAR PROFILE_REQUEST_COLLEGE).freeze
+DUMMY_XML_RESPONSE =
+  <<~HEREDOC
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ServiceResponse>
+      <Record>
+          <Login>foo</Login>
+          <Gender>F</Gender>
+          <FirstName>Jane</FirstName>
+          <LastName>Smith</LastName>
+          <Email>jane.smith@example.com</Email>
+          <AltId>123456</AltId>
+          <ClassYear>2018</ClassYear>
+          <College>AB</College>
+      </Record>
+    </ServiceResponse>
+  HEREDOC
+DUMMY_PROFILE_HASH = { first_name: 'Jane', last_name: 'Smith',
+                       email: 'jane.smith@example.com', gender: 'female',
+                       class_year: '2018', college: 'AB' }.freeze
+
+RSpec.describe IDRProfileQuerier do
+  describe '.query' do
+    it 'calls :query on an instance of IDRProfileQuerier' do
+      profile_querier = mock_profile_querier(id: 'foo')
+      described_class.query(id: 'foo')
+      expect(profile_querier).to have_received(:query)
+    end
+  end
+
+  describe '#query' do
+    context 'success' do
+      before do
+        assign_required_attributes
+        stub_profile_request
+      end
+      it 'returns profile data with properly mapped gender' do
+        result = described_class.query(id: 'bar')
+        expect(result).to eq(DUMMY_PROFILE_HASH)
+      end
+    end
+
+    context 'missing config params' do
+      before { allow(ENV).to receive(:[]).with(any_args).and_return(true) }
+      REQUIRED_CONFIG_PARAMS.each do |param|
+        it "returns an empty hash if missing #{param}" do
+          allow(ENV).to receive(:[]).with(param).and_return(false)
+          result = described_class.query(id: 'foo')
+          expect(result).to eq({})
+        end
+      end
+    end
+  end
+
+  def mock_profile_querier(**params)
+    instance_spy('IDRProfileQuerier').tap do |profile_querier|
+      allow(IDRProfileQuerier).to receive(:new).with(**params)
+        .and_return(profile_querier)
+    end
+  end
+
+  def assign_required_attributes
+    allow(ENV).to receive(:[]).and_return(nil)
+    REQUIRED_CONFIG_PARAMS.each do |param|
+      val = mock_val(param)
+      allow(ENV).to receive(:[]).with(param).and_return(val)
+    end
+  end
+
+  def mock_val(param)
+    return 'https://foo.example.com/' unless param.match(/URL/).nil?
+    return 'foo' unless param.match(/QUERY_PARAM/).nil?
+    param_tag(param)
+  end
+
+  def param_tag(param)
+    param.gsub('PROFILE_REQUEST_', '').split('_').map(&:capitalize).join('')
+  end
+
+  def stub_profile_request(id: 'bar')
+    stub_request(:get, 'https://foo.example.com')
+      .with(query: { 'foo' => id })
+      .to_return(body: DUMMY_XML_RESPONSE)
+  end
+end

--- a/spec/services/user_builder_spec.rb
+++ b/spec/services/user_builder_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe UserBuilder do
         result = described_class.build(id_attr: 'foo')
         expect(result[:user].persisted?).to be_falsey
       end
+      it 'looks up profile data' do
+        querier = mock_profile_querier(first_name: 'John')
+        result = described_class.new(id_attr: 'foo', querier: querier).build
+        expect(result[:user][:first_name]).to eq('John')
+      end
       it 'returns a success flash' do
         result = described_class.build(id_attr: 'foo')
         expect(result[:msg]).to have_key(:success)
@@ -75,6 +80,12 @@ RSpec.describe UserBuilder do
     instance_spy('UserBuilder').tap do |user_builder|
       allow(UserBuilder).to receive(:new).with(params_hash)
         .and_return(user_builder)
+    end
+  end
+
+  def mock_profile_querier(**profile_data)
+    class_spy('IdrProfileQuerier').tap do |pq|
+      allow(pq).to receive(:query).and_return(profile_data)
     end
   end
 end


### PR DESCRIPTION
Resolves #129
- Add ProfileRequester service object to handle the lookup of profile data from a web service and the parsing of XML results
- Add profile lookup as a step in the UserBuilder