### PR TITLE
[117] Add suite selection for drawless groups

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -2,7 +2,8 @@
 #
 # Controller class for 'special' (admin-created outside of draw) housing groups.
 class DrawlessGroupsController < ApplicationController
-  prepend_before_action :set_group, only: %i(show edit update destroy)
+  prepend_before_action :set_group, only: %i(show edit update destroy
+                                             select_suite)
   before_action :set_form_data, only: %i(new edit)
 
   def show; end
@@ -29,6 +30,11 @@ class DrawlessGroupsController < ApplicationController
     handle_action(**result)
   end
 
+  def select_suite
+    result = SuiteSelector.select(group: @group, suite_id: params['suite'])
+    handle_action(action: 'show', **result)
+  end
+
   private
 
   def authorize!
@@ -36,7 +42,7 @@ class DrawlessGroupsController < ApplicationController
   end
 
   def drawless_group_params
-    params.require(:group).permit(:size, :leader_id, member_ids: [])
+    params.require(:group).permit(:size, :leader_id, :suite, member_ids: [])
   end
 
   def set_group

--- a/app/helpers/drawless_groups_helper.rb
+++ b/app/helpers/drawless_groups_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+#
+# Helper module for drawless groups
+module DrawlessGroupsHelper
+  def suite_collection(group)
+    available = Suite.available.to_a
+    return available unless group.suite
+    available.insert(0, group.suite)
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,6 +10,7 @@
 class Group < ApplicationRecord
   belongs_to :leader, class_name: 'User'
   belongs_to :draw
+  has_one :suite
   has_many :memberships, dependent: :delete_all
   has_many :members, through: :memberships, source: :user
 

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -12,6 +12,7 @@
 # @attr [Array<Room>] rooms has_many association for the Rooms within the Suite.
 class Suite < ApplicationRecord
   belongs_to :building
+  belongs_to :group
   has_many :rooms
   has_and_belongs_to_many :draws # rubocop:disable Rails/HasAndBelongsToMany
 
@@ -19,4 +20,6 @@ class Suite < ApplicationRecord
   validates :number, presence: true, uniqueness: { scope: :building }
   validates :size, presence: true,
                    numericality: { greater_than_or_equal_to: 0 }
+
+  scope :available, -> { where(group_id: nil).order(:number) }
 end

--- a/app/policies/drawless_group_policy.rb
+++ b/app/policies/drawless_group_policy.rb
@@ -2,4 +2,7 @@
 #
 # Policy for permissions on special (non-draw) housing groups
 class DrawlessGroupPolicy < ApplicationPolicy
+  def select_suite?
+    user.admin? && record.locked?
+  end
 end

--- a/app/services/suite_selector.rb
+++ b/app/services/suite_selector.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+#
+# Service object to select suites for a given group.
+class SuiteSelector
+  # Allow for :select to be called on the parent class
+  def self.select(**params)
+    new(**params).select
+  end
+
+  # Initialize a new SuiteSelector
+  #
+  # @param group [Group] the group to assign the suite to
+  # @param suite_id [Integer] the suite id to assign to the group
+  def initialize(group:, suite_id:)
+    @group = group
+    @suite_id = suite_id
+    @errors = []
+  end
+
+  # Select / assign a suite to a group. Checks to make sure that the grou does
+  # not curretly have a suite assigned, that the suite_id corresponds to an
+  # existing suite, and that the suite is not currently assigned to a different
+  # group.
+  #
+  # @return [Hash{symbol=>Group,Hash}] a results hash with a message to set in
+  #   the flash, nil or the group as the :object, and an action to render.
+  def select
+    if assign_suite_to_group
+      success
+    else
+      error
+    end
+  end
+
+  private
+
+  attr_accessor :errors
+  attr_reader :group, :suite_id, :suite
+
+  def valid?
+    if group_already_has_suite
+      errors << 'Group already has a suite assigned.'
+    elsif suite_does_not_exist
+      errors << 'Suite does not exist.'
+    elsif suite_already_assigned
+      errors << 'Suite is assigned to a different group'
+    end
+    errors.empty?
+  end
+
+  def group_already_has_suite
+    group.suite.present?
+  end
+
+  def suite_does_not_exist
+    @suite ||= Suite.find_by(suite_id)
+    suite.nil?
+  end
+
+  def suite_already_assigned
+    suite.group_id.present?
+  end
+
+  def assign_suite_to_group
+    return false unless valid?
+    return true if suite.update(group: group)
+    errors << suite.errors.full_messages.join("\n")
+    false
+  end
+
+  def success
+    {
+      object: group,
+      msg: { success: "Suite #{suite.number} assigned to #{group.name}" }
+    }
+  end
+
+  def error
+    {
+      object: nil,
+      msg: { error: "Oops, there was a problem:\n#{errors.join("\n")}" }
+    }
+  end
+end

--- a/app/services/user_builder.rb
+++ b/app/services/user_builder.rb
@@ -25,9 +25,9 @@ class UserBuilder
 
   # Build a user record based on the given input, ensuring that it is unique
   #
-  # @return [Hash{symbol=>User,Hash}] a results hash with a message to set in
-  #   the flash, nil as the :object value, the user record as the :user value,
-  #   and the :action to render. The :object is always set to nil so that
+  # @return [Hash{symbol=>User,Hash,String}] a results hash with a message to
+  #   set in the flash, nil as the :object value, the user record as the :user
+  #   value, and the :action to render. The :object is always set to nil so that
   #   handle_action properly renders the template set in :action.
   def build
     return error unless unique?

--- a/app/views/drawless_groups/show.html.erb
+++ b/app/views/drawless_groups/show.html.erb
@@ -1,2 +1,9 @@
 <%= render partial: 'groups/group_details' %>
+<% if policy(DrawlessGroup.new(@group)).select_suite? %>
+  <h2>Assign Suite</h2>
+  <%= simple_form_for @group, url: select_suite_group_path(@group), method: :patch do |f| %>
+    <%= f.input :suite, collection: suite_collection(@group), label_method: :number, selected: @group.suite.try(:id) %>
+    <%= f.submit 'Assign suite' %>
+  <% end %>
+<% end %>
 <%= link_to 'Delete', group_path(@group), method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,6 @@ Rails.application.routes.draw do
   post 'draws/:id/intent_report', to: 'draws#filter_intent_report'
 
   resources :groups, controller: 'drawless_groups'
+  patch 'groups/:id/select_suite', to: 'drawless_groups#select_suite',
+                                   as: 'select_suite_group'
 end

--- a/db/migrate/20170202064324_add_group_association_to_suites.rb
+++ b/db/migrate/20170202064324_add_group_association_to_suites.rb
@@ -1,0 +1,5 @@
+class AddGroupAssociationToSuites < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :suites, :group
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201052315) do
+ActiveRecord::Schema.define(version: 20170202064324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,7 +88,9 @@ ActiveRecord::Schema.define(version: 20170201052315) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
     t.integer  "size",        default: 0, null: false
+    t.integer  "group_id"
     t.index ["building_id"], name: "index_suites_on_building_id", using: :btree
+    t.index ["group_id"], name: "index_suites_on_group_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/features/groups/drawless_group_suite_assignment_spec.rb
+++ b/spec/features/groups/drawless_group_suite_assignment_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Drawless group suite assignment' do
+  let(:group) { FactoryGirl.create(:drawless_group) }
+  context 'as admin' do
+    before { log_in(FactoryGirl.create(:admin)) }
+    it 'can be performed' do # rubocop:disable RSpec/ExampleLength
+      group.update(status: 'locked')
+      visit group_path(group)
+      suite = Suite.where(size: group.size).first
+      select suite.number, from: 'group_suite'
+      click_button 'Assign suite'
+      expect(page).to \
+        have_content("Suite #{suite.number} assigned to #{group.name}")
+    end
+  end
+end

--- a/spec/helpers/drawless_groups_helper_spec.rb
+++ b/spec/helpers/drawless_groups_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'simple_form'
+
+RSpec.describe DrawlessGroupsHelper, tyep: :helper do
+  describe '#suite_collection' do
+    it 'returns a sorted list of available suites if no suite assigned' do
+      expected = mock_suite_list(%w(112 24 12))
+      group = instance_spy('group', suite: nil)
+      expect(helper.suite_collection(group)).to eq(expected)
+    end
+    it 'returns a sorted list with the group suite at the start' do
+      available_sorted = mock_suite_list(%w(112 24 12))
+      suite = FactoryGirl.create(:suite, number: '1242', group_id: 123)
+      group = instance_spy('group', suite: suite)
+      expect(helper.suite_collection(group)).to \
+        eq([suite] + available_sorted)
+    end
+
+    def mock_suite_list(suite_numbers)
+      suite_list = suite_numbers.map do |n|
+        FactoryGirl.create(:suite, number: n)
+      end
+      result = instance_spy('ActiveRecord::Relation',
+                            to_a: suite_list.sort_by!(&:number))
+      allow(Suite).to receive(:available).and_return(result)
+      suite_list.sort_by(&:number)
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Group, type: :model do
     it { is_expected.to belong_to(:leader) }
     it { is_expected.to validate_presence_of(:leader) }
     it { is_expected.to belong_to(:draw) }
+    it { is_expected.to have_one(:suite) }
     it { is_expected.to have_many(:memberships) }
     it { is_expected.to have_many(:members).through(:memberships) }
     it { is_expected.not_to allow_value(-1).for(:memberships_count) }

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Suite, type: :model do
   describe 'basic validations' do
     it { is_expected.to validate_presence_of(:number) }
     it { is_expected.to belong_to(:building) }
+    it { is_expected.to belong_to(:group) }
     it { is_expected.to have_many(:rooms) }
     it { is_expected.to have_and_belong_to_many(:draws) }
 
@@ -20,6 +21,18 @@ RSpec.describe Suite, type: :model do
         FactoryGirl.create(:suite, **attrs)
         suite = FactoryGirl.build(:suite, **attrs)
         expect(suite.valid?).to be_falsey
+      end
+    end
+  end
+
+  context 'scopes' do
+    describe '.available' do
+      it 'returns all suites not assigned to groups ordered by number' do
+        suite1 = FactoryGirl.create(:suite, number: 'def')
+        suite2 = FactoryGirl.create(:suite, number: 'abc')
+        FactoryGirl.create(:suite, group_id: 1234)
+        expect(described_class.available.map(&:id)).to \
+          eq([suite2.id, suite1.id])
       end
     end
   end

--- a/spec/policies/drawless_group_policy_spec.rb
+++ b/spec/policies/drawless_group_policy_spec.rb
@@ -20,8 +20,21 @@ RSpec.describe DrawlessGroupPolicy do
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
+    let(:group) { FactoryGirl.build_stubbed(:group) }
     permissions :new? do
       it { is_expected.to permit(user, DrawlessGroup) }
+    end
+    context 'full group' do
+      before { allow(group).to receive(:locked?).and_return(true) }
+      permissions :select_suite? do
+        it { is_expected.to permit(user, group) }
+      end
+    end
+    context 'not full group' do
+      before { allow(group).to receive(:locked?).and_return(false) }
+      permissions :select_suite? do
+        it { is_expected.not_to permit(user, group) }
+      end
     end
   end
 end

--- a/spec/services/suite_selector_spec.rb
+++ b/spec/services/suite_selector_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuiteSelector do
+  describe '.select' do
+    it 'calls :select on a new instance of SuiteSelector' do
+      group = instance_spy('group')
+      suite_selector = mock_suite_selector(group: group, suite_id: 123)
+      described_class.select(group: group, suite_id: 123)
+      expect(suite_selector).to have_received(:select)
+    end
+  end
+
+  describe '#select' do
+    context 'failure' do
+      it 'checks that the group has no suite' do
+        group = instance_spy('group',
+                             suite: instance_spy('suite', present?: true))
+        suite = mock_suite(id: 123)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:object]).to be_nil
+      end
+      it 'checks that the suite exists' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123, present: false)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:object]).to be_nil
+      end
+      it 'checks that the suite is not already assigned' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123, has_group: true)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:object]).to be_nil
+      end
+      it 'fails if the update fails' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123, update: false)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets an error message in the flash' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123, present: false)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:msg].keys).to include(:error)
+      end
+    end
+    context' success' do
+      it 'sets the object to the group' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:object]).to eq(group)
+      end
+      it 'updates the suite to belong to the group' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123)
+        described_class.select(group: group, suite_id: suite.id)
+        expect(suite).to have_received(:update).with(group: group)
+      end
+      it 'sets a success message in the flash' do
+        group = instance_spy('group', suite: nil)
+        suite = mock_suite(id: 123)
+        result = described_class.select(group: group, suite_id: suite.id)
+        expect(result[:msg].keys).to include(:success)
+      end
+    end
+  end
+
+  def mock_suite_selector(params)
+    instance_spy('suite_selector').tap do |suite_selector|
+      allow(SuiteSelector).to receive(:new).with(params)
+        .and_return(suite_selector)
+    end
+  end
+
+  # rubocop:disable AbcSize
+  def mock_suite(id:, present: true, has_group: false, update: true)
+    instance_spy('suite', id: id).tap do |suite|
+      presence = present ? suite : nil
+      allow(Suite).to receive(:find_by).with(id).and_return(presence)
+      allow(suite).to receive(:group_id).and_return(123) if has_group
+      allow(suite).to receive(:update).and_return(update)
+    end
+  end
+  # rubocop:enable AbcSize
+end


### PR DESCRIPTION
Resolves #117
- Add SuiteSelector service object to handle suite assignment to groups
- Add select_suite action to DrawlessGroupsController
- Add Suite.available scope