### PR TITLE
[141] Add has_many :memberships to User

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -43,7 +43,8 @@ class GroupsController < ApplicationController
 
   def accept_request
     user = User.includes(:membership).find(params['user_id'])
-    result = MembershipUpdater.update(membership: user.membership,
+    membership = user.memberships.where(group: @group).first
+    result = MembershipUpdater.update(membership: membership,
                                       params: { status: 'accepted' })
     handle_action(path: draw_group_path(@draw, @group), **result)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,9 @@ class User < ApplicationRecord
   end
 
   belongs_to :draw
-  has_one :membership, dependent: :destroy
+  has_one :membership, -> { where(status: 'accepted') }, dependent: :destroy
   has_one :group, through: :membership
+  has_many :memberships, dependent: :destroy
 
   validates :email, uniqueness: true
   validates :username, presence: true, if: :cas_auth?

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -10,6 +10,27 @@ RSpec.describe Membership, type: :model do
     it { is_expected.to validate_presence_of(:status) }
   end
 
+  describe 'user uniqueness' do
+    it 'is scoped to group' do
+      user = FactoryGirl.create(:student_in_draw)
+      group = FactoryGirl.create(:group, leader: user, draw: user.draw)
+      membership = Membership.new(group: group, user: user)
+      expect(membership).not_to be_valid
+    end
+  end
+
+  describe 'user can only have one accepted membership' do
+    it do # rubocop:disable RSpec/ExampleLength
+      draw = FactoryGirl.create(:draw_with_members, students_count: 2)
+      leader = draw.students.first
+      FactoryGirl.create(:group, leader: leader)
+      other_group = FactoryGirl.create(:open_group, leader: draw.students.last)
+      m = Membership.new(user_id: leader.id, status: 'accepted',
+                         group: other_group)
+      expect(m).not_to be_valid
+    end
+  end
+
   describe 'group draw and user draw must match' do
     it do
       user = FactoryGirl.create(:student_in_draw)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:gender) }
     it { is_expected.to belong_to(:draw) }
     it { is_expected.to have_one(:membership) }
+    it { is_expected.to have_many(:memberships) }
     it { is_expected.to have_one(:group).through(:membership) }
   end
 
@@ -70,6 +71,36 @@ RSpec.describe User, type: :model do
       user = FactoryGirl.build_stubbed(:user, first_name: 'Sydney',
                                               last_name: 'Young')
       expect(user.full_name).to eq(full_name)
+    end
+  end
+
+  describe '#group' do
+    it 'returns nil if no accepted membership' do
+      group = FactoryGirl.create(:open_group)
+      user = FactoryGirl.create(:student, draw: group.draw)
+      Membership.create(user: user, group: group, status: 'requested')
+      expect(user.reload.group).to be_nil
+    end
+    it 'returns the group of the accepted membership' do
+      group = FactoryGirl.create(:open_group)
+      user = FactoryGirl.create(:student, draw: group.draw)
+      Membership.create(user: user, group: group, status: 'accepted')
+      expect(user.reload.group).to eq(group)
+    end
+  end
+
+  describe '#membership' do
+    it 'returns nil if no accepted membership' do
+      group = FactoryGirl.create(:open_group)
+      user = FactoryGirl.create(:student, draw: group.draw)
+      Membership.create(user: user, group: group, status: 'requested')
+      expect(user.reload.membership).to be_nil
+    end
+    it 'returns the accepted membership' do
+      group = FactoryGirl.create(:open_group)
+      user = FactoryGirl.create(:student, draw: group.draw)
+      m = Membership.create(user: user, group: group, status: 'accepted')
+      expect(user.reload.membership).to eq(m)
     end
   end
 end


### PR DESCRIPTION
Resolves #141
 - Users can only have one accepted membership
 - User#group is only set with an accepted membership
 - Users can only have one membership per group