### PR TITLE
[154] Implement admin editing of drawless groups

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -20,9 +20,10 @@ class DrawlessGroupsController < ApplicationController
   def edit; end
 
   def update
-    result = Updater.new(object: @group, name_method: :name,
-                         params: drawless_group_params).update
-    @group = result[:record]
+    result = DrawlessGroupUpdater.update(group: @group,
+                                         params: drawless_group_params)
+    @group = result[:group]
+    set_form_data unless result[:object]
     handle_action(action: 'edit', **result)
   end
 
@@ -43,7 +44,8 @@ class DrawlessGroupsController < ApplicationController
   end
 
   def drawless_group_params
-    params.require(:group).permit(:size, :leader_id, :suite, member_ids: [])
+    params.require(:group).permit(:size, :leader_id, :suite, member_ids: [],
+                                                             remove_ids: [])
   end
 
   def set_group
@@ -52,7 +54,7 @@ class DrawlessGroupsController < ApplicationController
 
   def set_form_data
     @group ||= Group.new
-    @students = UngroupedStudentsQuery.call + @group.members
+    @students = UngroupedStudentsQuery.call
     @suite_sizes = SuiteSizesQuery.call
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -79,6 +79,7 @@ class GroupsController < ApplicationController
 
   def group_params
     params.require(:group).permit(:size, :leader_id, member_ids: [],
+                                                     remove_ids: [],
                                                      invitations: [])
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -29,6 +29,8 @@ class Group < ApplicationRecord
 
   before_validation :add_leader_to_members, if: ->(g) { g.leader.present? }
 
+  attr_reader :remove_ids
+
   def name
     "#{leader.name}'s Group"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,9 +67,47 @@ class User < ApplicationRecord
 
   # Returns the user's preferred full name
   #
-  # @return [String] Preferred name if set, otherwise first name, plus last name
+  # @return [String] First name plus last name
   def full_name
     "#{name} #{last_name}"
+  end
+
+  # Returns the user's full name with their intent in parentheses
+  #
+  # @return [String] Full name with user's intent in parentheses
+  def full_name_with_intent
+    "#{full_name} (#{pretty_intent})"
+  end
+
+  # Returns the user's intent not in snake case (replaces underscores with
+  # spaces)
+  #
+  # @return [String] the non-snake case intent
+  def pretty_intent
+    intent.tr('_', ' ')
+  end
+
+  # Back up a user's current draw into old_draw_id and removes them from current
+  # draw, also setting intent to undeclared. Does nothing if draw_id is nil.
+  #
+  # @return [User] the modified but unpersisted user object
+  def remove_draw
+    return self if draw_id.nil?
+    old_draw_id = draw_id
+    assign_attributes(draw_id: nil, old_draw_id: old_draw_id,
+                      intent: 'undeclared')
+    self
+  end
+
+  # Restores a user's draw from old_draw_id and clears old_draw_id, also setting
+  # intent to undeclared. Does nothing if old_draw_id is nil.
+  #
+  # @return [User] the modified but unpersisted user object
+  def restore_draw
+    return self if old_draw_id.nil?
+    draw_id = old_draw_id
+    assign_attributes(draw_id: draw_id, old_draw_id: nil, intent: 'undeclared')
+    self
   end
 
   private

--- a/app/services/creators/group_creator.rb
+++ b/app/services/creators/group_creator.rb
@@ -16,6 +16,7 @@ class GroupCreator < Creator
     @params = params.to_h.transform_keys(&:to_sym)
     add_draw_to_params if params[:leader_id]
     remove_blank_members if params[:member_ids]
+    remove_remove_ids_from_params if params[:remove_ids]
   end
 
   def add_draw_to_params
@@ -24,6 +25,10 @@ class GroupCreator < Creator
 
   def remove_blank_members
     @params[:member_ids] = params[:member_ids].reject(&:empty?)
+  end
+
+  def remove_remove_ids_from_params
+    @params.delete(:remove_ids)
   end
 
   def success(group)

--- a/app/services/updaters/drawless_group_updater.rb
+++ b/app/services/updaters/drawless_group_updater.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+#
+# Service object to update special (drawless) groups
+class DrawlessGroupUpdater < Updater
+  # Allows calling of :update on parent class
+  def self.update(**params)
+    new(**params).update
+  end
+
+  # Instantiates a new DrawlessGroupUpdater
+  #
+  # @param group [Group] the group
+  # @param params [#to_h] the params from the controller
+  def initialize(group:, params:)
+    @group = group
+    process_params(params)
+  end
+
+  # Update the group
+  #
+  # @return [Hash{Symbol=>Group,Hash,Nil}] the return hash
+  def update
+    ActiveRecord::Base.transaction do
+      remove_users if pending_users[:remove]
+      group.reload
+      add_users if pending_users[:add]
+      group.update!(params)
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_accessor :pending_users, :group, :params
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @pending_users = { add: users(:member_ids), remove: users(:remove_ids) }
+    delete_user_id_keys_from_params
+    delete_leader_id_if_empty
+  end
+
+  def users(key)
+    return nil unless params.key? key
+    User.find(params[key].reject(&:empty?))
+  end
+
+  def delete_user_id_keys_from_params
+    params.delete(:member_ids) if params[:member_ids]
+    params.delete(:remove_ids) if params[:remove_ids]
+  end
+
+  def delete_leader_id_if_empty
+    params.delete(:leader_id) if params[:leader_id]
+  end
+
+  # Note that this occurs within the transaction
+  def remove_users
+    Membership.where(user_id: pending_users[:remove].map(&:id)).destroy_all
+    pending_users[:remove].each { |user| user.restore_draw.save! }
+  end
+
+  # Note that this occurs within the transaction
+  def add_users
+    pending_users[:add].each do |user|
+      user.remove_draw.update!(intent: 'on_campus')
+      group.members << user
+    end
+  end
+
+  def success
+    {
+      object: group, group: group,
+      msg: { success: 'Group successfully updated!' }
+    }
+  end
+
+  def error(error)
+    {
+      object: nil, group: group,
+      msg: { error: "Group update failed: #{error}" }
+    }
+  end
+end

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,6 +1,7 @@
 <%= f.input :size, collection: @suite_sizes %>
 <% if current_user.admin? %>
-  <%= f.association :leader, label_method: :full_name, collection: @students %>
-  <%= f.association :members, label_method: :full_name, collection: @students %>
+  <%= f.association :leader, label_method: :full_name_with_intent, collection: @students %>
+  <%= f.input :remove_ids, label: 'Users to remove', collection: @group.members, label_method: :full_name, as: :select, input_html: { multiple: true } %>
+  <%= f.association :members, label: 'Users to add', label_method: :full_name_with_intent, collection: @students %>
 <% end %>
 <%= f.submit %>

--- a/app/views/groups/_group_details.html.erb
+++ b/app/views/groups/_group_details.html.erb
@@ -4,6 +4,6 @@
 <h2 class="group-members">Members:</h2>
 <ul>
   <% @group.members.each do |m| %>
-    <li><%= m.full_name %></li>
+    <li class="group-member"><%= m.full_name %></li>
   <% end %>
 </ul>

--- a/db/migrate/20170208040633_add_old_draw_id_to_users.rb
+++ b/db/migrate/20170208040633_add_old_draw_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddOldDrawIdToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :old_draw_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170202064324) do
+ActiveRecord::Schema.define(version: 20170208040633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20170202064324) do
     t.string   "username"
     t.integer  "class_year"
     t.string   "college"
+    t.integer  "old_draw_id"
     t.index ["draw_id"], name: "index_users_on_draw_id", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree

--- a/spec/features/groups/drawless_group_editing_spec.rb
+++ b/spec/features/groups/drawless_group_editing_spec.rb
@@ -2,15 +2,38 @@
 require 'rails_helper'
 
 RSpec.feature 'Special group editing' do
-  let(:group) { FactoryGirl.create(:drawless_group) }
   before { log_in FactoryGirl.create(:admin) }
 
-  it 'succeeds' do
+  it 'succeeds when changing size' do
+    group = FactoryGirl.create(:drawless_group)
     new_suite = FactoryGirl.create(:suite_with_rooms, rooms_count: 5)
     visit edit_group_path(group)
     update_group_size(new_suite.size)
     expect(page).to have_css('.group-size', text: new_suite.size)
   end
+
+  # rubocop:disable RSpec/ExampleLength
+  it 'succeeds when switching in a user from a draw' do
+    group = FactoryGirl.create(:drawless_group, size: 2)
+    remove = FactoryGirl.create(:student, intent: 'on_campus')
+    group.members << remove
+    add = FactoryGirl.create(:student_in_draw, intent: 'off_campus')
+    visit edit_group_path(group)
+    select remove.full_name, from: 'group_remove_ids'
+    select add.full_name_with_intent, from: 'group_member_ids'
+    click_on 'Save'
+    expect(page).to have_css('.group-member', text: add.full_name)
+  end
+
+  it 'fails even when memberships are invalid' do
+    group = FactoryGirl.create(:drawless_group, size: 1)
+    add = FactoryGirl.create(:student_in_draw)
+    visit edit_group_path(group)
+    select add.full_name_with_intent, from: 'group_member_ids'
+    click_on 'Save'
+    expect(page).to have_css('.flash-error')
+  end
+  # rubocop:enable RSpec/ExampleLength
 
   def update_group_size(new_size)
     select new_size, from: 'group_size'

--- a/spec/services/creators/drawless_group_creator_spec.rb
+++ b/spec/services/creators/drawless_group_creator_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe DrawlessGroupCreator do
       expect(described_class.new(params).create![:object]).to \
         be_instance_of(Group)
     end
+    it 'assigns the :old_draw_id of the students to their original draws' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: params_hash_with_draw_students)
+      leader = described_class.new(params).create![:object].leader
+      # rubocop:disable RSpec/InstanceVariable
+      # Note the use of @leader to access the original object
+      expect(leader.old_draw_id).to eq(@leader.draw_id)
+      # rubocop:enable RSpec/InstanceVariable
+    end
     it 'automatically sets the intents of members if necessary' do
       params = instance_spy('ActionController::Parameters',
                             to_h: params_hash_with_undeclared_intent_student)
@@ -29,6 +38,11 @@ RSpec.describe DrawlessGroupCreator do
     it 'returns a success flash message' do
       params = instance_spy('ActionController::Parameters', to_h: params_hash)
       expect(described_class.new(params).create![:msg]).to have_key(:success)
+    end
+    it 'ignores the :remove_ids parameter' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: params_hash.merge('remove_ids' => ['1']))
+      expect(described_class.new(params).create![:object]).to be_truthy
     end
   end
 

--- a/spec/services/creators/group_creator_spec.rb
+++ b/spec/services/creators/group_creator_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe GroupCreator do
       expect(described_class.new(params).create![:object].map(&:class)).to \
         eq([Draw, Group])
     end
+    it 'ignores the :remove_ids parameter' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: params_hash.merge('remove_ids' => ['1']))
+      expect(described_class.new(params).create![:object]).to be_truthy
+    end
   end
 
   it 'does not create when given invalid params' do

--- a/spec/services/updaters/drawless_group_updater_spec.rb
+++ b/spec/services/updaters/drawless_group_updater_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawlessGroupUpdater do
+  describe '.update' do
+    xit 'allows for calling :update on the parent class' do
+    end
+  end
+
+  describe '#update' do
+    # rubocop:disable RSpec/ExampleLength
+    context 'group is full' do
+      it 'deletes memberships for users being removed before updating' do
+        group = FactoryGirl.create(:drawless_group, size: 2)
+        to_remove = FactoryGirl.create(:student, intent: 'on_campus')
+        group.members << to_remove
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'remove_ids' => [to_remove.id.to_s] })
+        expect { described_class.update(group: group, params: p) }.to \
+          change(Membership, :count).by(-1)
+      end
+    end
+
+    context 'users being added' do
+      it 'moves the draw_id attribute to old_draw_id' do
+        group = FactoryGirl.create(:drawless_group, size: 2)
+        to_add = FactoryGirl.create(:student, draw_id: 1)
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'member_ids' => [to_add.id.to_s] })
+        described_class.update(group: group, params: p)
+        expect(to_add.reload.old_draw_id).to eq(1)
+      end
+      it 'updates their intent to on_campus if necessary' do
+        group = FactoryGirl.create(:drawless_group, size: 2)
+        to_add = FactoryGirl.create(:student, intent: 'undeclared')
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'member_ids' => [to_add.id.to_s] })
+        described_class.update(group: group, params: p)
+        expect(to_add.reload.intent).to eq('on_campus')
+      end
+    end
+
+    context 'users being removed' do
+      it 'moves the old_draw_id attribute to draw_id' do
+        group = FactoryGirl.create(:drawless_group, size: 2)
+        to_remove = FactoryGirl.create(:student, intent: 'on_campus',
+                                                 old_draw_id: 1)
+        group.members << to_remove
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'remove_ids' => [to_remove.id.to_s] })
+        described_class.update(group: group, params: p)
+        expect(to_remove.reload.draw_id).to eq(1)
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    context 'success' do
+      it 'sets to the :object to the group' do
+        group = instance_spy('group', update!: true)
+        p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
+        result = described_class.update(group: group, params: p)
+        expect(result[:object]).to eq(group)
+      end
+      it 'sets the :group to the group' do
+        group = instance_spy('group', update!: true)
+        p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
+        result = described_class.update(group: group, params: p)
+        expect(result[:group]).to eq(group)
+      end
+      it 'sets a success message' do
+        group = instance_spy('group', update!: true)
+        p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
+        result = described_class.update(group: group, params: p)
+        expect(result[:msg]).to have_key(:success)
+      end
+    end
+    context 'failure' do
+      it 'sets the :object to nil' do
+        group = instance_spy('group')
+        allow(group).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
+        result = described_class.update(group: group, params: p)
+        expect(result[:group]).to eq(group)
+      end
+      it 'sets an error message' do
+        group = instance_spy('group')
+        allow(group).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+        p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
+        result = described_class.update(group: group, params: p)
+        expect(result[:msg]).to have_key(:error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #154
- Add DrawlessGroupUpdater service object
- Add old_draw_id parameter to users

~~Still needs the DrawlessGroupCreator updated to store existing student draws in `old_draw_id`, but otherwise this should be pretty close.~~ I think this is good to go!