### PR TITLE
[159] Prevent admins from removing a group leader

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -22,7 +22,7 @@ class DrawlessGroupsController < ApplicationController
   def update
     result = DrawlessGroupUpdater.update(group: @group,
                                          params: drawless_group_params)
-    @group = result[:group]
+    @group = result[:record]
     set_form_data unless result[:object]
     handle_action(action: 'edit', **result)
   end
@@ -55,6 +55,7 @@ class DrawlessGroupsController < ApplicationController
   def set_form_data
     @group ||= Group.new
     @students = UngroupedStudentsQuery.call
+    @leader_students = @group.members.empty? ? @students : @group.members
     @suite_sizes = SuiteSizesQuery.call
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -26,6 +26,7 @@ class GroupsController < ApplicationController
   def update
     result = GroupUpdater.new(group: @group, params: group_params).update
     @group = result[:record]
+    set_form_data unless result[:object]
     handle_action(path: edit_draw_group_path(@draw, @group), **result)
   end
 
@@ -93,8 +94,8 @@ class GroupsController < ApplicationController
 
   def set_form_data
     @group ||= Group.new(draw: @draw)
-    @students = UngroupedStudentsQuery.new(@draw.students).call +
-                @group.members
+    @students = UngroupedStudentsQuery.new(@draw.students).call
+    @leader_students = @group.members.empty? ? @students : @group.members
     @suite_sizes = @draw.suite_sizes
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -12,7 +12,9 @@ class Group < ApplicationRecord
   belongs_to :draw
   has_one :suite
   has_many :memberships, dependent: :delete_all
-  has_many :members, through: :memberships, source: :user
+  has_many :full_memberships, -> { where(status: 'accepted') },
+           class_name: 'Membership', inverse_of: :group
+  has_many :members, through: :full_memberships, source: :user
 
   enum status: %w(open full locked)
 
@@ -57,6 +59,14 @@ class Group < ApplicationRecord
   # @return [Array<User>] the users who have been invited to join the group
   def invitations
     memberships.where(status: 'invited').map(&:user)
+  end
+
+  # Get the group's members that can be removed
+  #
+  # @return[Array<User>] the members of the group with the exception of the
+  #   group leader
+  def removable_members
+    members.reject { |u| u.id == leader_id }
   end
 
   private

--- a/app/services/updaters/drawless_group_updater.rb
+++ b/app/services/updaters/drawless_group_updater.rb
@@ -44,6 +44,7 @@ class DrawlessGroupUpdater < Updater
 
   def users(key)
     return nil unless params.key? key
+    return nil if key == :remove_ids && params[key] == group.leader_id.to_s
     User.find(params[key].reject(&:empty?))
   end
 
@@ -72,14 +73,14 @@ class DrawlessGroupUpdater < Updater
 
   def success
     {
-      object: group, group: group,
+      object: group, record: group,
       msg: { success: 'Group successfully updated!' }
     }
   end
 
   def error(error)
     {
-      object: nil, group: group,
+      object: nil, record: group,
       msg: { error: "Group update failed: #{error}" }
     }
   end

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,7 +1,9 @@
 <%= f.input :size, collection: @suite_sizes %>
 <% if current_user.admin? %>
-  <%= f.association :leader, label_method: :full_name_with_intent, collection: @students %>
-  <%= f.input :remove_ids, label: 'Users to remove', collection: @group.members, label_method: :full_name, as: :select, input_html: { multiple: true } %>
+  <%= f.association :leader, label_method: :full_name_with_intent, collection: @leader_students %>
+  <% unless @group.removable_members.empty? %>
+    <%= f.input :remove_ids, label: 'Users to remove', collection: @group.removable_members, label_method: :full_name, as: :select, input_html: { multiple: true } %>
+  <% end %>
   <%= f.association :members, label: 'Users to add', label_method: :full_name_with_intent, collection: @students %>
 <% end %>
 <%= f.submit %>

--- a/spec/services/updaters/drawless_group_updater_spec.rb
+++ b/spec/services/updaters/drawless_group_updater_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe DrawlessGroupUpdater do
         described_class.update(group: group, params: p)
         expect(to_remove.reload.draw_id).to eq(1)
       end
+      it 'does not remove the leader if passed' do
+        group = FactoryGirl.create(:drawless_group, size: 2)
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'remove_ids' => [group.leader_id.to_s] })
+        expect { described_class.update(group: group, params: p) }.not_to \
+          change(Membership, :count)
+      end
     end
     # rubocop:enable RSpec/ExampleLength
 
@@ -65,7 +72,7 @@ RSpec.describe DrawlessGroupUpdater do
         group = instance_spy('group', update!: true)
         p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
         result = described_class.update(group: group, params: p)
-        expect(result[:group]).to eq(group)
+        expect(result[:record]).to eq(group)
       end
       it 'sets a success message' do
         group = instance_spy('group', update!: true)
@@ -80,7 +87,7 @@ RSpec.describe DrawlessGroupUpdater do
         allow(group).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
         p = instance_spy('ActionController::Parameters', to_h: { size: 4 })
         result = described_class.update(group: group, params: p)
-        expect(result[:group]).to eq(group)
+        expect(result[:record]).to eq(group)
       end
       it 'sets an error message' do
         group = instance_spy('group')


### PR DESCRIPTION
Resolves #159
- Add Group#removable_members helper method
- Add :accepted_memberships conditional has_many association to use for has_many :members, through: :accepted_memberships
- Add @leader_students variable to GroupsController and DrawlessGroipsController for leader dropdown

Blocked on merging of #160, will need to be rebased following that merge.

Also resolves #161