### PR TITLE
[120] Prevent group actions on non-pre-lottery draws

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
                                              request_to_join accept_request
                                              invite_to_join edit_invitations
                                              accept_invitation)
-  before_action :set_draw
+  prepend_before_action :set_draw
   before_action :set_form_data, only: %i(new edit)
 
   def show; end
@@ -74,6 +74,7 @@ class GroupsController < ApplicationController
     else
       authorize Group
     end
+    authorize @draw, :group_actions?
   end
 
   def group_params

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -22,6 +22,10 @@ class DrawPolicy < ApplicationPolicy
     intent_report?
   end
 
+  def group_actions?
+    user.admin? || record.pre_lottery?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
           g.members << create(:student, draw: g.draw)
         end
       end
+      after(:create) { |g| g.draw.update(status: 'pre_lottery') }
     end
 
     factory :open_group do
@@ -21,6 +22,7 @@ FactoryGirl.define do
       after(:build) do |g|
         g.draw.suites << create(:suite_with_rooms, rooms_count: g.size)
       end
+      after(:create) { |g| g.draw.update(status: 'pre_lottery') }
     end
 
     factory :drawless_group do

--- a/spec/features/groups/group_creation_spec.rb
+++ b/spec/features/groups/group_creation_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Housing Group Creation' do
     let!(:leader) { FactoryGirl.create(:student_in_draw) }
 
     it 'succeeds' do
+      leader.draw.update(status: 'pre_lottery')
       suite = leader.draw.suites.first
       create_group(size: suite.size, leader: leader)
       expect(page).to have_css('.group-name', text: "#{leader.name}'s Group")

--- a/spec/features/groups/group_editing_spec.rb
+++ b/spec/features/groups/group_editing_spec.rb
@@ -4,7 +4,10 @@ require 'rails_helper'
 RSpec.feature 'Group editing' do
   let(:group) { FactoryGirl.create(:group) }
 
-  before { log_in group.leader }
+  before do
+    group.draw.update(status: 'pre_lottery')
+    log_in group.leader
+  end
   it 'succeeds' do
     new_suite = FactoryGirl.create(:suite_with_rooms, rooms_count: 5,
                                                       draws: [group.draw])

--- a/spec/features/groups/request_to_join_spec.rb
+++ b/spec/features/groups/request_to_join_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Students Joining Groups' do
 
   context 'requesting to join a full group' do
     it 'fails' do
-      group = FactoryGirl.create(:group)
+      group = FactoryGirl.create(:full_group)
       log_in FactoryGirl.create(:student, intent: 'on_campus', draw: group.draw)
       visit draw_group_path(group.draw, group)
       click_on 'Request To Join'

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -17,6 +17,17 @@ RSpec.describe DrawPolicy do
     permissions :index? do
       it { is_expected.not_to permit(user, Draw) }
     end
+
+    permissions :group_actions? do
+      context 'non-pre-lottery draw' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+      context 'pre-lottery draw' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+    end
   end
 
   context 'housing rep' do
@@ -31,12 +42,22 @@ RSpec.describe DrawPolicy do
     permissions :index? do
       it { is_expected.not_to permit(user, Draw) }
     end
+    permissions :group_actions? do
+      context 'non-pre-lottery draw' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+      context 'pre-lottery draw' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+    end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :show?, :update?, :create?, :destroy?, :intent_report?,
-                :filter_intent_report? do
+                :filter_intent_report?, :group_actions? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index? do


### PR DESCRIPTION
Resolves #120
- Add after(:create) callback to :open_group and :full_group factories to automatically update the draw status to pre_lottery
- Add :group_actions? permission to DrawPolicy and call it in the authorize! method of GroupsController