### PR TITLE
[40] Ensure that validation errors are shown on forms

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,0 +1,6 @@
+.input {
+  margin-bottom: 1rem;
+
+  input, select, textarea { margin-bottom: 0.1rem; }
+  .error { color: $alert-color; }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import "foundation_and_overrides";
 @import "nav";
 @import "flashes";
+@import "forms";

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -12,7 +12,7 @@ class BuildingsController < ApplicationController
 
   def create
     result = BuildingCreator.new(building_params).create!
-    @building = result[:object] ? result[:object] : Building.new
+    @building = result[:record]
     handle_action(action: 'new', **result)
   end
 
@@ -22,6 +22,7 @@ class BuildingsController < ApplicationController
   def update
     result = Updater.new(object: @building, name_method: :name,
                          params: building_params).update
+    @building = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -12,7 +12,7 @@ class DrawlessGroupsController < ApplicationController
 
   def create
     result = DrawlessGroupCreator.new(drawless_group_params).create!
-    @group = result[:group] ? result[:group] : Group.new
+    @group = result[:record]
     set_form_data unless result[:object]
     handle_action(path: new_group_path, **result)
   end
@@ -22,6 +22,7 @@ class DrawlessGroupsController < ApplicationController
   def update
     result = Updater.new(object: @group, name_method: :name,
                          params: drawless_group_params).update
+    @group = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -15,7 +15,7 @@ class DrawsController < ApplicationController
 
   def create
     result = DrawCreator.new(draw_params).create!
-    @draw = result[:object] ? result[:object] : Draw.new
+    @draw = result[:record]
     handle_action(action: 'new', **result)
   end
 
@@ -25,6 +25,7 @@ class DrawsController < ApplicationController
   def update
     result = Updater.new(object: @draw, name_method: :name,
                          params: draw_params).update
+    @draw = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -16,11 +16,8 @@ class GroupsController < ApplicationController
     p = group_params.to_h
     p[:leader_id] = current_user.id unless current_user.admin?
     result = GroupCreator.new(p).create!
-    if result[:group]
-      @group = result[:group]
-    else
-      set_form_data
-    end
+    @group = result[:group]
+    set_form_data unless result[:object]
     handle_action(path: new_draw_group_path(@draw), **result)
   end
 
@@ -28,6 +25,7 @@ class GroupsController < ApplicationController
 
   def update
     result = GroupUpdater.new(group: @group, params: group_params).update
+    @group = result[:record]
     handle_action(path: edit_draw_group_path(@draw, @group), **result)
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -12,7 +12,7 @@ class RoomsController < ApplicationController
 
   def create
     result = RoomCreator.new(room_params).create!
-    @room = result[:object] ? result[:object] : Room.new
+    @room = result[:record]
     handle_action(action: 'new', **result)
   end
 
@@ -22,6 +22,7 @@ class RoomsController < ApplicationController
   def update
     result = Updater.new(object: @room, name_method: :number,
                          params: room_params).update
+    @room = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/controllers/suites_controller.rb
+++ b/app/controllers/suites_controller.rb
@@ -12,7 +12,7 @@ class SuitesController < ApplicationController
 
   def create
     result = SuiteCreator.new(suite_params).create!
-    @suite = result[:object] ? result[:object] : Suite.new
+    @suite = result[:record]
     handle_action(action: 'new', **result)
   end
 
@@ -22,6 +22,7 @@ class SuitesController < ApplicationController
   def update
     result = Updater.new(object: @suite, name_method: :number,
                          params: suite_params).update
+    @suite = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,6 +12,7 @@ class UsersController < ApplicationController
   end
 
   def new
+    redirect_to(build_user_path) && return unless params['user']
     result = UserBuilder.build(id_attr: build_user_params['username'],
                                querier: querier)
     @user = result[:user]
@@ -20,7 +21,7 @@ class UsersController < ApplicationController
 
   def create
     result = UserCreator.new(user_params).create!
-    @user = result[:object] ? result[:object] : User.new
+    @user = result[:user]
     handle_action(action: 'new', **result)
   end
 
@@ -29,6 +30,7 @@ class UsersController < ApplicationController
   def update
     result = Updater.new(object: @user, name_method: :name,
                          params: user_params).update
+    @user = result[:record]
     handle_action(action: 'edit', **result)
   end
 

--- a/app/services/creators/creator.rb
+++ b/app/services/creators/creator.rb
@@ -27,7 +27,7 @@ class Creator
     if obj.save
       success(obj)
     else
-      error(obj.errors.full_messages)
+      error(obj)
     end
   end
 
@@ -36,12 +36,16 @@ class Creator
   attr_reader :klass, :params, :name_method
 
   def success(obj)
-    { object: obj, msg: { success: "#{obj.send(name_method)} created." } }
+    {
+      object: obj, record: obj,
+      msg: { success: "#{obj.send(name_method)} created." }
+    }
   end
 
-  def error(errors)
+  def error(obj)
+    errors = obj.errors.full_messages
     {
-      object: nil,
+      object: nil, record: obj,
       msg: { error: "Please review the errors below:\n#{errors.join("\n")}" }
     }
   end

--- a/app/services/creators/drawless_group_creator.rb
+++ b/app/services/creators/drawless_group_creator.rb
@@ -24,7 +24,7 @@ class DrawlessGroupCreator < Creator
     end
     success(group)
   rescue ActiveRecord::RecordInvalid
-    error(group.errors.full_messages)
+    error(group)
   end
 
   private

--- a/app/services/creators/membership_creator.rb
+++ b/app/services/creators/membership_creator.rb
@@ -25,9 +25,10 @@ class MembershipCreator < Creator
         "#{membership.user.name}." } }
   end
 
-  def error(errors)
+  def error(membership)
+    errors = membership.errors.full_messages
     {
-      object: nil,
+      object: nil, membership: membership,
       msg: { error: "Please review the errors below:\n#{errors.join("\n")}" },
       errors: errors,
       params: params

--- a/app/services/updaters/group_updater.rb
+++ b/app/services/updaters/group_updater.rb
@@ -13,7 +13,7 @@ class GroupUpdater < Updater
   private
 
   def success
-    { object: [object.draw, object],
+    { object: [object.draw, object], record: object,
       msg: { success: "#{object.send(name_method)} updated." } }
   end
 end

--- a/app/services/updaters/updater.rb
+++ b/app/services/updaters/updater.rb
@@ -21,7 +21,7 @@ class Updater
   #   A results hash with a message to set in the flash and either `nil`
   #   or the updated object.
   def update
-    if object.update_attributes(**params)
+    if object.update(**params)
       success
     else
       error
@@ -33,10 +33,17 @@ class Updater
   attr_reader :object, :params, :name_method
 
   def success
-    { object: object, msg: { notice: "#{object.send(name_method)} updated." } }
+    {
+      object: object, record: object,
+      msg: { notice: "#{object.send(name_method)} updated." }
+    }
   end
 
   def error
-    { object: nil, msg: { error: 'Please review the errors below.' } }
+    errors = object.errors.full_messages
+    {
+      object: nil, record: object,
+      msg: { error: "Please review the errors below:\n#{errors.join("\n")}" }
+    }
   end
 end

--- a/app/services/user_builder.rb
+++ b/app/services/user_builder.rb
@@ -30,7 +30,8 @@ class UserBuilder
   #   value, and the :action to render. The :object is always set to nil so that
   #   handle_action properly renders the template set in :action.
   def build
-    return error if exists?
+    return invalid_error if id_attr.empty?
+    return duplicate_error if exists?
     assign_login
     assign_profile_attrs
     success
@@ -60,7 +61,12 @@ class UserBuilder
                       msg: { success: 'Initialized user successfully' })
   end
 
-  def error
+  def invalid_error
+    result_hash.merge(action: 'build',
+                      msg: { error: 'You must enter a username / e-mail' })
+  end
+
+  def duplicate_error
     result_hash.merge(action: 'build',
                       msg: { error: 'User already exists' })
   end

--- a/spec/services/creators/building_creator_spec.rb
+++ b/spec/services/creators/building_creator_spec.rb
@@ -2,19 +2,32 @@
 require 'rails_helper'
 
 RSpec.describe BuildingCreator do
-  it 'sucessfully creates a building' do
-    params = instance_spy('ActionController::Parameters',
-                          to_h: { name: 'Silliman' })
-    expect(described_class.new(params).create![:object]).to \
-      be_instance_of(Building)
+  context 'success' do
+    it 'sucessfully creates a building' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: { name: 'Silliman' })
+      expect(described_class.new(params).create![:object]).to \
+        be_instance_of(Building)
+    end
+    it 'returns the building object' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: { name: 'Silliman' })
+      expect(described_class.new(params).create![:record]).to \
+        be_instance_of(Building)
+    end
+    it 'returns a success flash message' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: { name: 'Silliman' })
+      expect(described_class.new(params).create![:msg]).to have_key(:success)
+    end
   end
   it 'does not create when given invalid params' do
     params = instance_spy('ActionController::Parameters', to_h: { name: nil })
     expect(described_class.new(params).create![:object]).to be_nil
   end
-  it 'returns a success flash message' do
-    params = instance_spy('ActionController::Parameters',
-                          to_h: { name: 'Silliman' })
-    expect(described_class.new(params).create![:msg]).to have_key(:success)
+  it 'returns the building object even with invalid params' do
+    params = instance_spy('ActionController::Parameters', to_h: { name: nil })
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Building)
   end
 end

--- a/spec/services/creators/draw_creator_spec.rb
+++ b/spec/services/creators/draw_creator_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe DrawCreator do
       expect(described_class.new(params).create![:object]).to \
         be_instance_of(Draw)
     end
+    it 'returns the draw object' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: FactoryGirl.attributes_for(:draw))
+      expect(described_class.new(params).create![:record]).to \
+        be_instance_of(Draw)
+    end
     it 'returns a success flash message' do
       params = instance_spy('ActionController::Parameters',
                             to_h: FactoryGirl.attributes_for(:draw))
@@ -19,5 +25,10 @@ RSpec.describe DrawCreator do
   it 'does not create when given invalid params' do
     params = instance_spy('ActionController::Parameters', to_h: { name: nil })
     expect(described_class.new(params).create![:object]).to be_nil
+  end
+  it 'returns the draw object even if saving failed' do
+    params = instance_spy('ActionController::Parameters', to_h: { name: nil })
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Draw)
   end
 end

--- a/spec/services/creators/drawless_group_creator_spec.rb
+++ b/spec/services/creators/drawless_group_creator_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe DrawlessGroupCreator do
       expect(described_class.new(params).create![:object]).to \
         be_instance_of(Group)
     end
+    it 'returns the group object' do
+      params = instance_spy('ActionController::Parameters',
+                            to_h: params_hash_with_undeclared_intent_student)
+      expect(described_class.new(params).create![:record]).to \
+        be_instance_of(Group)
+    end
     it 'returns a success flash message' do
       params = instance_spy('ActionController::Parameters', to_h: params_hash)
       expect(described_class.new(params).create![:msg]).to have_key(:success)
@@ -30,7 +36,11 @@ RSpec.describe DrawlessGroupCreator do
     params = instance_spy('ActionController::Parameters', to_h: {})
     expect(described_class.new(params).create![:object]).to be_nil
   end
-
+  it 'returns the group object even if invalid' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Group)
+  end
   it 'does not persist changes to members if save fails' do
     student = FactoryGirl.create(:student, intent: 'undeclared')
     params = instance_spy('ActionController::Parameters',

--- a/spec/services/creators/group_creator_spec.rb
+++ b/spec/services/creators/group_creator_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe GroupCreator do
     params = instance_spy('ActionController::Parameters', to_h: {})
     expect(described_class.new(params).create![:object]).to be_nil
   end
+  it 'returns the group even if invalid' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Group)
+  end
 
   # rubocop:disable RSpec/InstanceVariable
   def params_hash

--- a/spec/services/creators/membership_creator_spec.rb
+++ b/spec/services/creators/membership_creator_spec.rb
@@ -23,12 +23,10 @@ RSpec.describe MembershipCreator do
       expect(described_class.new(params).create![:membership]).to \
         be_instance_of(Membership)
     end
-
     it 'sets a success message in the flash' do
       params = instance_spy('ActionController::Parameters', to_h: params_hash)
       expect(described_class.new(params).create![:msg]).to have_key(:success)
     end
-
     # rubocop:disable RSpec/InstanceVariable
     def params_hash
       @group ||= FactoryGirl.create(:open_group)
@@ -42,5 +40,10 @@ RSpec.describe MembershipCreator do
   it 'does not create when given invalid params' do
     params = instance_spy('ActionController::Parameters', to_h: {})
     expect(described_class.new(params).create![:object]).to be_nil
+  end
+  it 'returns the membership even if invalid' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    expect(described_class.new(params).create![:membership]).to \
+      be_instance_of(Membership)
   end
 end

--- a/spec/services/creators/room_creator_spec.rb
+++ b/spec/services/creators/room_creator_spec.rb
@@ -2,21 +2,33 @@
 require 'rails_helper'
 
 RSpec.describe RoomCreator do
-  it 'sucessfully creates a room' do
-    params_hash = { number: 'L01',
-                    suite: FactoryGirl.build_stubbed(:suite) }
-    params = instance_spy('ActionController::Parameters', to_h: params_hash)
-    expect(described_class.new(params).create![:object]).to \
-      be_instance_of(Room)
+  context 'success' do
+    it 'sucessfully creates a room' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:object]).to \
+        be_instance_of(Room)
+    end
+    it 'returns the room object even with invalid params' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:record]).to \
+        be_instance_of(Room)
+    end
+    it 'returns a success flash message' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:msg]).to have_key(:success)
+    end
+
+    def params_hash
+      { number: 'L01', suite: FactoryGirl.build_stubbed(:suite) }
+    end
   end
   it 'does not create when given invalid params' do
     params = instance_spy('ActionController::Parameters', to_h: {})
     expect(described_class.new(params).create![:object]).to be_nil
   end
-  it 'returns a success flash message' do
-    params_hash = { number: 'L01',
-                    suite: FactoryGirl.build_stubbed(:suite) }
-    params = instance_spy('ActionController::Parameters', to_h: params_hash)
-    expect(described_class.new(params).create![:msg]).to have_key(:success)
+  it 'returns the room object even with invalid params' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Room)
   end
 end

--- a/spec/services/creators/suite_creator_spec.rb
+++ b/spec/services/creators/suite_creator_spec.rb
@@ -2,21 +2,32 @@
 require 'rails_helper'
 
 RSpec.describe SuiteCreator do
-  it 'sucessfully creates a suite' do
-    params_hash = { number: 'L01',
-                    building: FactoryGirl.build_stubbed(:building) }
-    params = instance_spy('ActionController::Parameters', to_h: params_hash)
-    expect(described_class.new(params).create![:object]).to \
-      be_instance_of(Suite)
+  context 'success' do
+    it 'sucessfully creates a suite' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:object]).to \
+        be_instance_of(Suite)
+    end
+    it 'returns the suite object' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:record]).to \
+        be_instance_of(Suite)
+    end
+    it 'returns a success flash message' do
+      params = instance_spy('ActionController::Parameters', to_h: params_hash)
+      expect(described_class.new(params).create![:msg]).to have_key(:success)
+    end
+    def params_hash
+      { number: 'L01', building: FactoryGirl.build_stubbed(:building) }
+    end
   end
   it 'does not create when given invalid params' do
     params = instance_spy('ActionController::Parameters', to_h: {})
     expect(described_class.new(params).create![:object]).to be_nil
   end
-  it 'returns a success flash message' do
-    params_hash = { number: 'L01',
-                    building: FactoryGirl.build_stubbed(:building) }
-    params = instance_spy('ActionController::Parameters', to_h: params_hash)
-    expect(described_class.new(params).create![:msg]).to have_key(:success)
+  it 'returns the suite even if invalid' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    expect(described_class.new(params).create![:record]).to \
+      be_instance_of(Suite)
   end
 end

--- a/spec/services/creators/user_creator_spec.rb
+++ b/spec/services/creators/user_creator_spec.rb
@@ -13,11 +13,17 @@ RSpec.describe UserCreator do
 
   describe '#create!' do
     context 'success' do
-      it 'returns a valid user' do
+      it 'creates a user' do
         params = instance_spy('ActionController::Parameters',
                               to_h: valid_params)
         result = described_class.create!(params)
-        expect(result[:object]).to be_an_instance_of(User)
+        expect(result[:object]).to be_instance_of(User)
+      end
+      it 'returns the user object' do
+        params = instance_spy('ActionController::Parameters',
+                              to_h: valid_params)
+        result = described_class.create!(params)
+        expect(result[:user]).to be_instance_of(User)
       end
       it 'returns a success message' do
         params = instance_spy('ActionController::Parameters',
@@ -60,10 +66,15 @@ RSpec.describe UserCreator do
     end
 
     context 'failure' do
-      it 'returns the invalid user' do
+      it 'sets :object to nil' do
         params = instance_spy('ActionController::Parameters', to_h: {})
         result = described_class.create!(params)
         expect(result[:object]).to be_nil
+      end
+      it 'returns the invalid user' do
+        params = instance_spy('ActionController::Parameters', to_h: {})
+        result = described_class.create!(params)
+        expect(result[:user]).to be_instance_of(User)
       end
       it 'returns an error message' do
         params = instance_spy('ActionController::Parameters', to_h: {})

--- a/spec/services/updaters/group_updater_spec.rb
+++ b/spec/services/updaters/group_updater_spec.rb
@@ -9,4 +9,11 @@ RSpec.describe GroupUpdater do
     updater = described_class.new(group: group, params: params)
     expect(updater.update[:object]).to eq([draw, group])
   end
+  it 'returns the group object' do
+    draw = instance_spy('Draw')
+    group = instance_spy('Group', draw: draw, update_attributes: true)
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    updater = described_class.new(group: group, params: params)
+    expect(updater.update[:record]).to eq(group)
+  end
 end

--- a/spec/services/updaters/updater_spec.rb
+++ b/spec/services/updaters/updater_spec.rb
@@ -4,30 +4,50 @@ require 'rails_helper'
 RSpec.describe Updater do
   it 'sucessfully updates a suite' do
     params = instance_spy('ActionController::Parameters', to_h: {})
-    suite = instance_spy('Suite', update_attributes: true)
+    suite = mock_suite(valid: true)
     updater = described_class.new(object: suite, name_method: :number,
                                   params: params)
     expect(updater.update[:object]).to eq(suite)
   end
-  it 'does not create when given invalid params' do
+  it 'returns the updated record' do
     params = instance_spy('ActionController::Parameters', to_h: {})
-    suite = instance_spy('Suite', update_attributes: false)
+    suite = mock_suite(valid: true)
+    updater = described_class.new(object: suite, name_method: :number,
+                                  params: params)
+    expect(updater.update[:record]).to eq(suite)
+  end
+  it 'does not update when given invalid params' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    suite = mock_suite(valid: false)
     updater = described_class.new(object: suite, name_method: :number,
                                   params: params)
     expect(updater.update[:object]).to be_nil
   end
+  it 'returns the record even if invalid' do
+    params = instance_spy('ActionController::Parameters', to_h: {})
+    suite = mock_suite(valid: false)
+    updater = described_class.new(object: suite, name_method: :number,
+                                  params: params)
+    expect(updater.update[:record]).to be_instance_of(suite.class)
+  end
   it 'returns a notice flash message on success' do
     params = instance_spy('ActionController::Parameters', to_h: {})
-    suite = instance_spy('Suite', update_attributes: true)
+    suite = mock_suite(valid: true)
     updater = described_class.new(object: suite, name_method: :number,
                                   params: params)
     expect(updater.update[:msg]).to have_key(:notice)
   end
   it 'returns an error flash message on failure' do
     params = instance_spy('ActionController::Parameters', to_h: {})
-    suite = instance_spy('Suite', update_attributes: false)
+    suite = mock_suite(valid: false)
     updater = described_class.new(object: suite, name_method: :number,
                                   params: params)
     expect(updater.update[:msg]).to have_key(:error)
+  end
+  def mock_suite(valid:)
+    instance_spy('Suite', update: valid).tap do |suite|
+      allow(suite).to receive(:errors)
+        .and_return(instance_spy('ActiveModel::Errors', full_messages: []))
+    end
   end
 end


### PR DESCRIPTION
Resolves #40
- Ensure that all creator and updater service objects return the record even if invalid
- Update styling of form errors