### PR TITLE
[104] Add oversubscription summary to draw page

### DIFF
--- a/app/helpers/draws_helper.rb
+++ b/app/helpers/draws_helper.rb
@@ -2,6 +2,8 @@
 #
 # Helper module for Draws
 module DrawsHelper
+  delegate :size_str, to: Suite
+
   def intent_deadline_str(draw)
     diff = (draw.intent_deadline - Time.zone.today).to_i
     if diff.positive?
@@ -11,6 +13,13 @@ module DrawsHelper
     else
       'The intent deadline is today.'
     end
+  end
+
+  def diff_class(diff)
+    raise ArgumentError unless diff.is_a? Integer
+    return 'positive' if diff.positive?
+    return 'negative' if diff.negative?
+    'zero'
   end
 
   private

--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -9,6 +9,7 @@
 #   TODO: lottery, post_lottery). Note the use of underscores in the status
 #   strings; this prevents some unpleasantness with the helper methods.
 class Draw < ApplicationRecord
+  has_many :groups
   has_many :students, class_name: 'User'
   has_and_belongs_to_many :suites # rubocop:disable Rails/HasAndBelongsToMany
 

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -11,6 +11,9 @@
 #   Suite is located in.
 # @attr [Array<Room>] rooms has_many association for the Rooms within the Suite.
 class Suite < ApplicationRecord
+  SIZE_STRS = { 1 => 'single', 2 => 'double', 3 => 'triple', 4 => 'quadruple',
+                5 => 'quintuple', 6 => 'sextuple', 7 => 'septuple',
+                8 => 'octuple' }.freeze
   belongs_to :building
   belongs_to :group
   has_many :rooms
@@ -22,4 +25,14 @@ class Suite < ApplicationRecord
                    numericality: { greater_than_or_equal_to: 0 }
 
   scope :available, -> { where(group_id: nil).order(:number) }
+
+  # Return the equivalent string for a given suite size
+  #
+  # @param size [Integer] the suite size
+  # @return [String] the equivalnet string
+  def self.size_str(size)
+    raise ArgumentError unless size.is_a?(Integer) && size.positive?
+    return SIZE_STRS[size] if SIZE_STRS.key? size
+    "#{size}-suite"
+  end
 end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -6,16 +6,12 @@ class DrawPolicy < ApplicationPolicy
     true
   end
 
-  def update?
-    user.rep? || user.admin?
-  end
-
   def activate?
-    user.admin? && record.draft?
+    edit? && record.draft?
   end
 
   def intent_report?
-    user.admin?
+    edit?
   end
 
   def filter_intent_report?
@@ -24,6 +20,14 @@ class DrawPolicy < ApplicationPolicy
 
   def group_actions?
     user.admin? || record.pre_lottery?
+  end
+
+  def intent_summary?
+    !record.draft?
+  end
+
+  def oversub_report?
+    !record.draft? && !record.suites.empty?
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/views/draws/_oversub_report.html.erb
+++ b/app/views/draws/_oversub_report.html.erb
@@ -1,0 +1,23 @@
+<h2>Draw Summary</h2>
+<table>
+  <thead>
+    <tr>
+      <td>Suite Size</td>
+      <td>Suites</td>
+      <td>Groups</td>
+      <td>Locked Groups</td>
+      <td>Leftover Suites</td>
+    </tr>
+  </thead>
+  <tbody>
+    <% @suite_sizes.each do |size| %>
+      <tr>
+        <td data-role="suite-size"><%= size %></td>
+        <td data-role="suite-count"><%= @suite_counts[size] %></td>
+        <td data-role="group-count"><%= @group_counts[size] %></td>
+        <td data-role="locked-count"><%= @locked_counts[size] %></td>
+        <td data-role="oversubscription" class="<%= diff_class(@diff[size]) %>"><%= @diff[size] %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -1,28 +1,34 @@
 <h1 class="draw-name"><%= @draw.name %></h1>
-<div class="intent-metrics">
-  <h2>Intent Metrics</h2>
-  <table>
-    <tbody>
-      <% @intent_metrics.each do |intent_value, count| %>
-        <tr>
-          <td class="metric-heading"><%= intent_value.humanize.capitalize %></td>
-          <td class="<%= intent_value %>-count"><%= count %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-  <% if @draw.pre_lottery? && @draw.intent_deadline %>
-    <p><%= intent_deadline_str(@draw) %></p>
-  <% end %>
-  <% if policy(@draw).intent_report? %>
-    <p><%= link_to 'View intent report', draw_intent_report_path(@draw) %></p>
-  <% end %>
-  <% if policy(@draw).activate? %>
-    <p><%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %></p>
-  <% end %>
-  <% if policy(@draw).update? %>
-    <p><%= link_to 'Add group to draw', new_draw_group_path(@draw) %></p>
-  <% end %>
-  <p><%= link_to 'Delete', draw_path(@draw), method: :delete %></p>
-</div>
-
+<% if policy(@draw).intent_summary? %>
+  <div class="intent-metrics">
+    <h2>Intent Metrics</h2>
+    <table>
+      <tbody>
+        <% @intent_metrics.each do |intent_value, count| %>
+          <tr>
+            <td class="metric-heading"><%= intent_value.humanize.capitalize %></td>
+            <td class="<%= intent_value %>-count"><%= count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <% if @draw.pre_lottery? && @draw.intent_deadline %>
+      <p><%= intent_deadline_str(@draw) %></p>
+    <% end %>
+    <% if policy(@draw).intent_report? %>
+      <p><%= link_to 'View intent report', draw_intent_report_path(@draw) %></p>
+    <% end %>
+  </div>
+<% end %>
+<% if policy(@draw).oversub_report? %>
+  <div class="oversub-report">
+    <%= render 'oversub_report' %>
+  </div>
+<% end %>
+<% if policy(@draw).activate? %>
+  <p><%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %></p>
+<% end %>
+<% if policy(@draw).update? %>
+  <p><%= link_to 'Add group to draw', new_draw_group_path(@draw) %></p>
+<% end %>
+<p><%= link_to 'Delete', draw_path(@draw), method: :delete %></p>

--- a/app/views/draws/suite_summary.html.erb
+++ b/app/views/draws/suite_summary.html.erb
@@ -1,0 +1,14 @@
+<h1 class="draw-name"><%= @draw.name %> Suites</h1>
+<% @all_sizes.each do |size| %>
+  <div class="suites-<%= size_str(size).pluralize %>">
+    <h2><%= size_str(size).pluralize.titleize %></h2>
+    <p><%= link_to 'Update', draw_suites_update_path(@draw, size), id: "update-suites-#{size}" %></p>
+    <% if @suites_by_size.has_key? size %>
+      <% @suites_by_size[size].each do |suite| %>
+        <div class="suite-item"><%= suite.number %></div>
+      <% end %>
+    <% end %>
+  </div>
+  <hr />
+<% end %>
+<%= link_to 'Return to draw', draw_path(@draw) %>

--- a/spec/features/draws/draw_intent_report_spec.rb
+++ b/spec/features/draws/draw_intent_report_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Draw intent report' do
-  let(:draw) { FactoryGirl.create(:draw) }
+  let(:draw) { FactoryGirl.create(:draw, status: 'pre_lottery') }
 
   it 'displays a table with intent data' do
     student = create_student_data(draw: draw, intents: %w(on_campus))

--- a/spec/features/draws/oversubscription_dashboard_spec.rb
+++ b/spec/features/draws/oversubscription_dashboard_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw oversubscription dashboard' do
+  let(:draw) do
+    FactoryGirl.create(:draw_with_members, students_count: 2, suites_count: 1,
+                                           status: 'pre_lottery')
+  end
+  before do
+    draw.students.each { |s| FactoryGirl.create(:group, leader: s, size: 1) }
+    draw.groups.first.update(status: 'locked')
+    log_in FactoryGirl.create(:admin)
+  end
+  it 'displays a table' do
+    visit draw_path(draw)
+    expect(page_has_oversubsription_report?(page)).to be_truthy
+  end
+
+  def page_has_oversubsription_report?(page)
+    page.assert_selector(:css, 'td[data-role="suite-count"]', text: '1') &&
+      page.assert_selector(:css, 'td[data-role="group-count"]', text: '2') &&
+      page.assert_selector(:css, 'td[data-role="locked-count"]', text: '1') &&
+      page.assert_selector(:css, 'td[data-role="oversubscription"]', text: '1')
+  end
+end

--- a/spec/helpers/draws_helper_spec.rb
+++ b/spec/helpers/draws_helper_spec.rb
@@ -21,4 +21,24 @@ RSpec.describe DrawsHelper, type: :helper do
         eq('The intent deadline is today.')
     end
   end
+
+  describe '#size_str' do
+    it 'delegates to Suite' do
+      allow(Suite).to receive(:size_str).with(1)
+      helper.size_str(1)
+      expect(Suite).to have_received(:size_str).with(1)
+    end
+  end
+
+  describe '#diff_class' do
+    it 'returns positive if diff is positive' do
+      expect(helper.diff_class(1)).to eq('positive')
+    end
+    it 'returns zero if diff is zero' do
+      expect(helper.diff_class(0)).to eq('zero')
+    end
+    it 'returns negative if diff is negative' do
+      expect(helper.diff_class(-1)).to eq('negative')
+    end
+  end
 end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Draw, type: :model do
   describe 'basic validations' do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to have_many(:students) }
+    it { is_expected.to have_many(:groups) }
     it { is_expected.to have_and_belong_to_many(:suites) }
     it { is_expected.to validate_presence_of(:status) }
   end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -48,4 +48,27 @@ RSpec.describe Suite, type: :model do
       expect(suite.size).to eq(size)
     end
   end
+
+  describe '.size_str' do
+    it 'raises an argument error if a non-integer is passed' do
+      size = instance_spy('string')
+      allow(size).to receive(:is_a?).with(Integer).and_return(false)
+      expect { described_class.size_str(size) }.to raise_error(ArgumentError)
+    end
+    it 'raises an argument error if a non-positive number is passed' do
+      size = instance_spy('integer')
+      allow(size).to receive(:positive?).and_return(false)
+      expect { described_class.size_str(size) }.to raise_error(ArgumentError)
+    end
+    context 'valid inputs' do
+      expected = { 1 => 'single', 2 => 'double', 3 => 'triple',
+                   4 => 'quadruple', 5 => 'quintuple', 6 => 'sextuple',
+                   7 => 'septuple', 8 => 'octuple', 9 => '9-suite' }
+      expected.each do |size, expected_str|
+        it "returns a valid result for #{size}" do
+          expect(described_class.size_str(size)).to eq(expected_str)
+        end
+      end
+    end
+  end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable RSpec/NestedGroups
 require 'rails_helper'
 
 RSpec.describe DrawPolicy do
@@ -10,8 +11,8 @@ RSpec.describe DrawPolicy do
     permissions :show? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :create?, :destroy?, :update?, :activate?, :intent_report?,
-                :filter_intent_report? do
+    permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
+                :intent_report?, :filter_intent_report? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -26,20 +27,52 @@ RSpec.describe DrawPolicy do
       context 'pre-lottery draw' do
         before { allow(draw).to receive(:pre_lottery?).and_return(true) }
         it { is_expected.to permit(user, draw) }
+      end
+    end
+
+    permissions :intent_summary? do
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.to permit(user, draw) }
+      end
+    end
+    permissions :oversub_report? do
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        context 'when draw has suites' do
+          before do
+            allow(draw).to receive(:suites)
+              .and_return([instance_spy('suite')])
+          end
+          it { is_expected.to permit(user, draw) }
+        end
+        context 'when draw has no suites' do
+          before { allow(draw).to receive(:suites).and_return([]) }
+          it { is_expected.not_to permit(user, draw) }
+        end
+      end
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
       end
     end
   end
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show?, :update? do
+    permissions :show? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :create?, :destroy?, :activate?, :intent_report?,
-                :filter_intent_report? do
+    permissions :create?, :edit?, :update?, :destroy?, :activate?,
+                :intent_report?, :filter_intent_report? do
       it { is_expected.not_to permit(user, draw) }
     end
-    permissions :index? do
+    permissions :new?, :index? do
       it { is_expected.not_to permit(user, Draw) }
     end
     permissions :group_actions? do
@@ -52,15 +85,48 @@ RSpec.describe DrawPolicy do
         it { is_expected.to permit(user, draw) }
       end
     end
+
+    permissions :intent_summary? do
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.to permit(user, draw) }
+      end
+    end
+
+    permissions :oversub_report? do
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        context 'when draw has suites' do
+          before do
+            allow(draw).to receive(:suites)
+              .and_return([instance_spy('suite')])
+          end
+          it { is_expected.to permit(user, draw) }
+        end
+        context 'when draw has no suites' do
+          before { allow(draw).to receive(:suites).and_return([]) }
+          it { is_expected.not_to permit(user, draw) }
+        end
+      end
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :show?, :update?, :create?, :destroy?, :intent_report?,
+    permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
                 :filter_intent_report?, :group_actions? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :index? do
+    permissions :index?, :new?, :create? do
       it { is_expected.to permit(user, Draw) }
     end
 
@@ -72,6 +138,39 @@ RSpec.describe DrawPolicy do
 
       context 'when draw is not a draft' do
         before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
+
+    permissions :intent_summary? do
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.to permit(user, draw) }
+      end
+    end
+
+    permissions :oversub_report? do
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        context 'when draw has suites' do
+          before do
+            allow(draw).to receive(:suites)
+              .and_return([instance_spy('suite')])
+          end
+          it { is_expected.to permit(user, draw) }
+        end
+        context 'when draw has no suites' do
+          before { allow(draw).to receive(:suites).and_return([]) }
+          it { is_expected.not_to permit(user, draw) }
+        end
+      end
+      context 'when draw is a draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
         it { is_expected.not_to permit(user, draw) }
       end
     end

--- a/spec/views/draws/show.html.erb_spec.rb
+++ b/spec/views/draws/show.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'draws/show.html.erb' do
-  let(:draw) { FactoryGirl.build(:draw, id: 1) }
+  let(:draw) { FactoryGirl.build(:draw, id: 1, status: 'pre_lottery') }
 
   context 'link to intent report' do
     it 'is displayed with the appropriate permissions' do
@@ -51,7 +51,10 @@ RSpec.describe 'draws/show.html.erb' do
   end
 
   def mock_user_and_policy(draw:, **stubs)
-    mock_policy = instance_spy('draw_policy', **stubs)
+    # Note that this hack-y stubbing is necessary to prevent issues while
+    # rendering the oversubscription report. In the future we should a) write
+    # specs for said report and b) stub things more elegantly.
+    mock_policy = instance_spy('draw_policy', oversub_report?: false, **stubs)
     without_partial_double_verification do
       allow(view).to receive(:policy).with(draw).and_return(mock_policy)
     end


### PR DESCRIPTION
Resolves #104
- Add / update draw policies for intent summary and oversub report
- Add Suite.size_str and associated method in DrawsHelper
- Add DrawsHelper#diff_class for styling
- Add has_many :groups to Draw (whoops)

Reviewed by @esoterik during pair programming