### PR TITLE
[175] Add suite summary page to draws

### DIFF
--- a/app/assets/stylesheets/_draws_suite_summary.scss
+++ b/app/assets/stylesheets/_draws_suite_summary.scss
@@ -1,0 +1,12 @@
+.suites-list {
+  @include grid-row;
+
+  .suite-item {
+    @include grid-column(12);
+
+    @include breakpoint(medium) {
+      @include grid-column(3);
+      @include grid-column-end;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "flashes";
 @import "forms";
 @import "inline_checkboxes_override";
+@import "draws_suite_summary";

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -52,6 +52,11 @@ class DrawsController < ApplicationController
     render action: 'intent_report'
   end
 
+  def suite_summary
+    @all_sizes = SuiteSizesQuery.new(Suite.available).call
+    @suites_by_size = SuitesBySizeQuery.new(@draw.suites.available).call
+  end
+
   private
 
   def authorize!
@@ -87,8 +92,8 @@ class DrawsController < ApplicationController
 
   def calculate_oversub_metrics # rubocop:disable AbcSize
     return unless policy(@draw).oversub_report?
-    @suite_sizes = SuiteSizesQuery.new(@draw.suites).call
-    @suite_counts = @draw.suites.group(:size).count
+    @suite_sizes = SuiteSizesQuery.new(@draw.suites.available).call
+    @suite_counts = @draw.suites.available.group(:size).count
     zeroed_group_hash = @suite_sizes.map { |s| [s, 0] }.to_h
     @group_counts = zeroed_group_hash.merge(@draw.groups.group(:size).count)
     @locked_counts = @draw.groups.where(status: 'locked').group(:size).count

--- a/app/helpers/drawless_groups_helper.rb
+++ b/app/helpers/drawless_groups_helper.rb
@@ -3,7 +3,7 @@
 # Helper module for drawless groups
 module DrawlessGroupsHelper
   def suite_collection(group)
-    available = Suite.available.to_a
+    available = Suite.available.order(:number).to_a
     return available unless group.suite
     available.insert(0, group.suite)
   end

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -11,9 +11,9 @@
 #   Suite is located in.
 # @attr [Array<Room>] rooms has_many association for the Rooms within the Suite.
 class Suite < ApplicationRecord
-  SIZE_STRS = { 1 => 'single', 2 => 'double', 3 => 'triple', 4 => 'quadruple',
-                5 => 'quintuple', 6 => 'sextuple', 7 => 'septuple',
-                8 => 'octuple' }.freeze
+  SIZE_STRS = { 1 => 'single', 2 => 'double', 3 => 'triple', 4 => 'quad',
+                5 => 'quint', 6 => 'sextet', 7 => 'septet',
+                8 => 'octet' }.freeze
   belongs_to :building
   belongs_to :group
   has_many :rooms
@@ -24,7 +24,7 @@ class Suite < ApplicationRecord
   validates :size, presence: true,
                    numericality: { greater_than_or_equal_to: 0 }
 
-  scope :available, -> { where(group_id: nil).order(:number) }
+  scope :available, -> { where(group_id: nil) }
 
   # Return the equivalent string for a given suite size
   #
@@ -33,6 +33,6 @@ class Suite < ApplicationRecord
   def self.size_str(size)
     raise ArgumentError unless size.is_a?(Integer) && size.positive?
     return SIZE_STRS[size] if SIZE_STRS.key? size
-    "#{size}-suite"
+    "#{size}-Pack"
   end
 end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -18,6 +18,10 @@ class DrawPolicy < ApplicationPolicy
     intent_report?
   end
 
+  def suite_summary?
+    show?
+  end
+
   def group_actions?
     user.admin? || record.pre_lottery?
   end

--- a/app/queries/suites_by_size_query.rb
+++ b/app/queries/suites_by_size_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+#
+# Query to return all suites, collected by suite size, for a passed relation.
+# Defaults to all suites.
+class SuitesBySizeQuery
+  # See IntentMetricsQuery for explanation
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize a SuitesBySizeQuery
+  #
+  # @param relation [Suite::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the query
+  #
+  # @return [Hash{Integer=>Array<Suite>}] the suites in the relation collected
+  #   by size
+  def call
+    @relation.order(:number).group_by(&:size)
+  end
+end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -25,6 +25,9 @@
     <%= render 'oversub_report' %>
   </div>
 <% end %>
+<% if policy(@draw).suite_summary? %>
+  <p><%= link_to 'View suites', draw_suite_summary_path(@draw) %></p>
+<% end %>
 <% if policy(@draw).activate? %>
   <p><%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %></p>
 <% end %>

--- a/app/views/draws/suite_summary.html.erb
+++ b/app/views/draws/suite_summary.html.erb
@@ -1,11 +1,10 @@
 <h1 class="draw-name"><%= @draw.name %> Suites</h1>
 <% @all_sizes.each do |size| %>
-  <div class="suites-<%= size_str(size).pluralize %>">
+  <div class="suites-list suites-<%= size_str(size).pluralize %>">
     <h2><%= size_str(size).pluralize.titleize %></h2>
-    <p><%= link_to 'Update', draw_suites_update_path(@draw, size), id: "update-suites-#{size}" %></p>
     <% if @suites_by_size.has_key? size %>
       <% @suites_by_size[size].each do |suite| %>
-        <div class="suite-item"><%= suite.number %></div>
+        <div class="suite-item"><%= link_to suite.number, suite_path(suite) %></div>
       <% end %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   get 'draws/:id/intent_report', to: 'draws#intent_report',
                                  as: 'draw_intent_report'
   post 'draws/:id/intent_report', to: 'draws#filter_intent_report'
+  get 'draws/:id/suites', to: 'draws#suite_summary', as: 'draw_suite_summary'
 
   resources :groups, controller: 'drawless_groups'
   patch 'groups/:id/select_suite', to: 'drawless_groups#select_suite',

--- a/spec/features/draws/draw_suite_summary_spec.rb
+++ b/spec/features/draws/draw_suite_summary_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw suite summary' do
+  let(:draw) { FactoryGirl.create(:draw_with_members, suites_count: 1) }
+  let(:draw_suite) { draw.suites.first }
+  let(:other_suite) { FactoryGirl.create(:suite) }
+
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'displays correctly' do
+    visit draw_path(draw)
+    click_on 'View suites'
+    expect(page_has_suite_summary?(page, draw_suite, other_suite)).to be_truthy
+  end
+
+  def page_has_suite_summary?(page, draw_suite, other_suite)
+    page_has_suite_content?(page, draw_suite) &&
+      page_does_not_have_suite_content?(page, other_suite)
+  end
+
+  def page_has_suite_content?(page, suite)
+    page.assert_selector(:css, '.suite-item a', text: suite.number)
+  end
+
+  def page_does_not_have_suite_content?(page, suite)
+    page.refute_selector(:css, '.suite-item a', text: suite.number)
+  end
+end

--- a/spec/helpers/drawless_groups_helper_spec.rb
+++ b/spec/helpers/drawless_groups_helper_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe DrawlessGroupsHelper, tyep: :helper do
         eq([suite] + available_sorted)
     end
 
-    def mock_suite_list(suite_numbers)
+    def mock_suite_list(suite_numbers) # rubocop:disable AbcSize
       suite_list = suite_numbers.map do |n|
         FactoryGirl.create(:suite, number: n)
       end
-      result = instance_spy('ActiveRecord::Relation',
-                            to_a: suite_list.sort_by!(&:number))
-      allow(Suite).to receive(:available).and_return(result)
+      instance_spy('ActiveRecord::Relation').tap do |suite_relation|
+        result = instance_spy('ActiveRecord::Relation',
+                              to_a: suite_list.sort_by!(&:number))
+        allow(suite_relation).to receive(:order).and_return(result)
+        allow(Suite).to receive(:available).and_return(suite_relation)
+      end
       suite_list.sort_by(&:number)
     end
   end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Suite, type: :model do
 
   context 'scopes' do
     describe '.available' do
-      it 'returns all suites not assigned to groups ordered by number' do
+      it 'returns all suites not assigned to groups' do
         suite1 = FactoryGirl.create(:suite, number: 'def')
         suite2 = FactoryGirl.create(:suite, number: 'abc')
         FactoryGirl.create(:suite, group_id: 1234)
         expect(described_class.available.map(&:id)).to \
-          eq([suite2.id, suite1.id])
+          eq([suite1.id, suite2.id])
       end
     end
   end
@@ -62,8 +62,8 @@ RSpec.describe Suite, type: :model do
     end
     context 'valid inputs' do
       expected = { 1 => 'single', 2 => 'double', 3 => 'triple',
-                   4 => 'quadruple', 5 => 'quintuple', 6 => 'sextuple',
-                   7 => 'septuple', 8 => 'octuple', 9 => '9-suite' }
+                   4 => 'quad', 5 => 'quint', 6 => 'sextet',
+                   7 => 'septet', 8 => 'octet', 9 => '9-Pack' }
       expected.each do |size, expected_str|
         it "returns a valid result for #{size}" do
           expect(described_class.size_str(size)).to eq(expected_str)

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DrawPolicy do
 
   context 'student' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
-    permissions :show? do
+    permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
@@ -65,7 +65,7 @@ RSpec.describe DrawPolicy do
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show? do
+    permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
@@ -123,7 +123,7 @@ RSpec.describe DrawPolicy do
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
-                :filter_intent_report?, :group_actions? do
+                :filter_intent_report?, :group_actions?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index?, :new?, :create? do

--- a/spec/queries/suites_by_size_query_spec.rb
+++ b/spec/queries/suites_by_size_query_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuitesBySizeQuery do
+  it 'returns a hash mapping suites to their sizes for the passed relation' do
+    suite = FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+    relation = Suite.where(size: 1)
+    result = described_class.new(relation).call
+    expect(result_numbers(result)).to eq(1 => [suite.number])
+  end
+
+  it 'returns a hash mapping suites to their sizes for all suties by default' do
+    suite1 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    suite2 = FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+    result = described_class.call
+    expect(result_numbers(result)).to \
+      eq(1 => [suite1.number], 2 => [suite2.number])
+  end
+
+  it 'orders suites by number' do
+    suite1 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1, number: 'b')
+    suite2 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1, number: 'a')
+    result = described_class.call
+    expect(result_numbers(result)).to eq(1 => [suite2.number, suite1.number])
+  end
+
+  def result_numbers(result)
+    result.map { |size, suites| [size, suites.map(&:number)] }.to_h
+  end
+end


### PR DESCRIPTION
Resolves #175
- Add suite summary page with a listing of all of the suites belonging
  to the draw, separated by suite size
- Add SuitesBySize query object