### PR TITLE
[158] Restore student draws when destroying drawless groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -31,6 +31,8 @@ class Group < ApplicationRecord
 
   before_validation :add_leader_to_members, if: ->(g) { g.leader.present? }
 
+  after_destroy :restore_member_draws, if: ->(g) { g.draw.nil? }
+
   attr_reader :remove_ids
 
   def name
@@ -111,5 +113,9 @@ class Group < ApplicationRecord
   def validate_full_locked
     return unless memberships_count != size
     errors.add :status, "can only be #{status} when members equal size"
+  end
+
+  def restore_member_draws
+    members.each { |u| u.restore_draw.save }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -132,4 +132,20 @@ RSpec.describe Group, type: :model do
       expect(group.removable_members.map(&:id)).not_to include(group.leader_id)
     end
   end
+
+  describe '#destroy' do
+    it 'restores members to their original draws if drawless' do
+      group = FactoryGirl.create(:drawless_group)
+      allow(group.leader).to receive(:restore_draw)
+        .and_return(instance_spy('user', save: true))
+      group.destroy
+      expect(group.leader).to have_received(:restore_draw)
+    end
+    it 'does nothing if group belongs to a draw' do
+      group = FactoryGirl.create(:group)
+      allow(group.leader).to receive(:restore_draw)
+      group.destroy
+      expect(group.leader).not_to have_received(:restore_draw)
+    end
+  end
 end

--- a/spec/queries/ungrouped_students_query_spec.rb
+++ b/spec/queries/ungrouped_students_query_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UngroupedStudentsQuery do
     students = %i(student rep).map { |r| FactoryGirl.create(:user, role: r) }
     _admin = FactoryGirl.create(:admin)
     result = described_class.call
-    expect(result).to eq(students)
+    expect(result.sort_by(&:id)).to eq(students)
   end
 
   it 'restricts the results to the passed query' do


### PR DESCRIPTION
Resolves #158 
- Add after_destroy callback on Group for drawless groups that restores the draws for each of its members