### PR TITLE
[118] Write spec to ensure group creation isn't broken

### DIFF
--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -42,6 +42,13 @@ RSpec.describe Group, type: :model do
       group.size = 1
       expect(group.valid?).to be_falsey
     end
+    it 'also validates during creation' do
+      leader, student = FactoryGirl.create_pair(:student)
+      group = described_class.new(size: 1, leader_id: leader.id,
+                                  member_ids: [student.id])
+      group.save
+      expect(group.persisted?).to be_falsey
+    end
   end
 
   describe 'status validations' do


### PR DESCRIPTION
Resolves #118 

This apparently is no longer broken? I think the spec is worth keeping, even though it broke at one point while coding but now seems to be passing.