### PR TITLE
[171, 172] Add user assignment and removal to draws by username

### DIFF
--- a/app/assets/stylesheets/_draws_student_summary.scss
+++ b/app/assets/stylesheets/_draws_student_summary.scss
@@ -1,3 +1,17 @@
+.student-assignment {
+  @include grid-row;
+
+  .bulk, .single {
+    @include grid-column(12);
+    padding-bottom: 1em;
+
+    @include breakpoint(medium) {
+      @include grid-column(6);
+      padding-bottom: 0;
+    }
+  }
+}
+
 .students-list {
   @include grid-row;
 

--- a/app/forms/draw_student_assignment_form.rb
+++ b/app/forms/draw_student_assignment_form.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+#
+# Form / service object for adding or removing a single user to/from a draw by
+# username. Removes them from their current draw (if they belong to one) and
+# saves their previeous draw ID so they can be restored.
+class DrawStudentAssignmentForm
+  include ActiveModel::Model
+
+  attr_accessor :username, :adding
+
+  validates :username, presence: true
+  validates :adding, inclusion: { in: [true, false] }
+  validate :student_found
+  validate :student_valid
+
+  # Allows for calling :submit on the parent class
+  def self.submit(**params)
+    new(**params).submit
+  end
+
+  # Initializes a DrawStudentAssignmentForm
+  #
+  # @param params [#to_h] parameters from controller
+  def initialize(draw:, params: nil)
+    @draw = draw
+    @adding = true
+    process_params(params) if params
+  end
+
+  # Execute the student update, either adding or removing the student in
+  # question. If the username is invalid or belongs to a user in a group,
+  # returns an error.
+  #
+  # @return Hash{Symbol=>Nil,DrawStudentAssignmentForm,Hash} a result hash
+  #   containing nil for the :object, the DrawStudentAssignmentForm set to
+  #   :update_object if there were any failures, and a flash message
+  def submit
+    return error(error_msgs) unless valid?
+    if adding?
+      student.remove_draw.update!(draw_id: draw.id)
+    else
+      student.restore_draw(save_current: true).save!
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_reader :draw, :student
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @username = @params[:username]
+    @adding = @params[:adding] == 'true'
+    @student = find_student
+  end
+
+  def find_student
+    return nil unless username
+    UngroupedStudentsQuery.call.find_by(username: username)
+  end
+
+  def student_found
+    return if student
+    errors.add(:username, 'must belong to a student not in a group')
+  end
+
+  def student_valid
+    return unless student
+    validate_addition if adding?
+    validate_removal if removing?
+  end
+
+  def validate_addition
+    return unless student.draw_id == draw.id
+    errors.add(:username,
+               'must belong to a student outside the draw when adding')
+  end
+
+  def validate_removal
+    return unless student.draw_id != draw.id
+    errors.add(:username,
+               'must belong to a student in the draw when removing')
+  end
+
+  def error_msgs
+    errors.full_messages.join(', ')
+  end
+
+  def success
+    verb = adding? ? 'added' : 'removed'
+    {
+      object: nil, update_object: nil,
+      msg: { success: "#{student.full_name} successfully #{verb}" }
+    }
+  end
+
+  def error(error)
+    {
+      object: nil, update_object: self,
+      msg: { error: "Student update failed: #{error}" }
+    }
+  end
+
+  def adding?
+    adding
+  end
+
+  def removing?
+    !adding?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,14 +99,18 @@ class User < ApplicationRecord
     self
   end
 
-  # Restores a user's draw from old_draw_id and clears old_draw_id, also setting
-  # intent to undeclared. Does nothing if old_draw_id is nil.
+  # Restores a user's draw from old_draw_id and optionally saves the current
+  # draw_id to old_draw_id, also setting intent to undeclared. If the draw_id is
+  # equal to the old_draw_id, will set draw_id to nil.
   #
+  # @param save_current [Boolean] whether or not to assign the current draw_id
+  #   value to old_draw_id, defaults to false
   # @return [User] the modified but unpersisted user object
-  def restore_draw
-    return self if old_draw_id.nil?
-    draw_id = old_draw_id
-    assign_attributes(draw_id: draw_id, old_draw_id: nil, intent: 'undeclared')
+  def restore_draw(save_current: false)
+    to_save = save_current ? draw_id : nil
+    new_draw_id = old_draw_id != draw_id ? old_draw_id : nil
+    assign_attributes(draw_id: new_draw_id, old_draw_id: to_save,
+                      intent: 'undeclared')
     self
   end
 

--- a/app/views/draws/student_summary.html.erb
+++ b/app/views/draws/student_summary.html.erb
@@ -1,17 +1,25 @@
 <h1 class="draw-name"><%= @draw.name %> Students</h1>
 <div class="student-assignment">
   <h2>Student actions</h2>
-  <% if @class_years.empty? %>
-    <p>There are no students available to add to this draw.</p>
-  <% else %>
-    <div class="bulk">
+  <div class="bulk">
+    <% if @available_students_count.zero? %>
+      <p>There are no students available to add to this draw.</p>
+    <% else %>
       <h3>Add students by class year</h3>
       <%= simple_form_for @students_update, url: draw_students_update_path(@draw), method: :patch do |f| %>
-        <%= f.input :class_year, as: :select, collection: @class_years %>
+        <%= f.input :class_year, as: :select, collection: @class_years, required: true %>
         <%= f.submit 'Assign students' %>
       <% end %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
+  <div class="single">
+    <h3>Add/Remove by NetID</h3>
+    <%= simple_form_for @student_assignment_form, url: draw_students_update_path(@draw), method: :patch do |f| %>
+      <%= f.input :username %>
+      <%= f.input :adding, label: 'Action', as: :radio_buttons, collection: [['Add', true], ['Remove', false]], required: true %>
+      <%= f.submit 'Process' %>
+    <% end %>
+  </div>
 </div>
 <hr />
 <div class="students-list">

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,9 +20,11 @@ module Vesta
     services_paths = %w(creators updaters destroyers).map do |s|
       "/app/services/#{s}"
     end
+    forms_path = %w(/app/forms)
     lib_paths = %w(seed).map { |s| "/lib/#{s}" }
-    config.autoload_paths += (services_paths + lib_paths + %w(/lib/)).map do |s|
-      "#{config.root}#{s}"
-    end
+    config.autoload_paths +=
+      (services_paths + forms_path + lib_paths + %w(/lib/)).map do |s|
+        "#{config.root}#{s}"
+      end
   end
 end

--- a/spec/features/draws/draw_student_assignment_spec.rb
+++ b/spec/features/draws/draw_student_assignment_spec.rb
@@ -19,4 +19,32 @@ RSpec.feature 'Draw student assignment' do
       click_on 'Assign students'
     end
   end
+
+  describe 'single user adding' do
+    let!(:student) { FactoryGirl.create(:student, username: 'foo') }
+    it 'can be performed' do
+      visit draw_student_summary_path(draw)
+      fill_in 'draw_student_assignment_form_username', with: 'foo'
+      click_on 'Process'
+      message = "#{student.full_name} successfully added"
+      expect(page).to have_css('.flash-success', text: message)
+    end
+  end
+
+  describe 'single user removing' do
+    let(:student) { FactoryGirl.create(:student, username: 'foo') }
+    before { draw.students << student }
+    it 'can be performed' do
+      visit draw_student_summary_path(draw)
+      remove_user(username: 'foo')
+      message = "#{student.full_name} successfully removed"
+      expect(page).to have_css('.flash-success', text: message)
+    end
+
+    def remove_user(username:)
+      fill_in 'draw_student_assignment_form_username', with: username
+      choose 'Remove'
+      click_on 'Process'
+    end
+  end
 end

--- a/spec/forms/draw_student_assignment_form_spec.rb
+++ b/spec/forms/draw_student_assignment_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawStudentAssignmentForm, type: :model do
+  let(:draw) { FactoryGirl.create(:draw) }
+  describe '.submit' do
+    xit 'allows for :submit to be called on the parent class'
+  end
+
+  describe 'validations' do
+    subject(:form_object) { described_class.new(draw: draw) }
+    it { is_expected.to validate_presence_of(:username) }
+    # commenting this out due to a shoulda_matchers warning
+    # it do
+    #   is_expected.to validate_inclusion_of(:adding).in_array([true, false])
+    # end
+    it 'validates that a valid student is found' do
+      klass = 'User::ActiveRecord_Relation'
+      allow(UngroupedStudentsQuery).to receive(:call)
+        .and_return(instance_spy(klass, find_by: nil))
+      expect(form_object.valid?).to be_falsey
+    end
+  end
+
+  describe '#submit' do
+    context 'adding a user success' do
+      it 'takes a username and adds the user' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        expect { described_class.submit(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(1)
+      end
+      it 'ignores grouped users' do
+        FactoryGirl.create(:drawless_group).leader.update(username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        expect { described_class.submit(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(0)
+      end
+      it 'sets :object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:update_object]).to be_nil
+      end
+      it 'sets a success message' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:success)
+      end
+    end
+
+    context 'failure' do
+      it 'sets :object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the form object' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        object = described_class.new(draw: draw, params: params)
+        expect(object.submit[:update_object]).to eq(object)
+      end
+      it 'sets an error message' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+    end
+
+    def mock_params(username: '', adding: nil)
+      hash = { username: username, adding: adding }
+      instance_spy('ActionController::Parameters', to_h: hash)
+    end
+  end
+end

--- a/spec/models/draw_students_update_spec.rb
+++ b/spec/models/draw_students_update_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe DrawStudentsUpdate do
       it 'bulk-adds users of a passed class year' do
         draw = FactoryGirl.create(:draw)
         FactoryGirl.create(:student, class_year: 2016)
-        params = mock_params(class_year: '2016')
+        params = mock_params(class_year: '2016', to_add: nil)
         expect { described_class.update(draw: draw, params: params) }.to \
           change { draw.students.count }.by(1)
       end
       it 'ignores students that are in other draws or groups' do
         draw = FactoryGirl.create(:draw)
         create_students_in_year(2016)
-        params = mock_params(class_year: '2016')
+        params = mock_params(class_year: '2016', to_add: nil)
         expect { described_class.update(draw: draw, params: params) }.to \
           change { draw.students.count }.by(1)
       end
@@ -103,8 +103,8 @@ RSpec.describe DrawStudentsUpdate do
       end
     end
 
-    def mock_params(class_year: '')
-      hash = { class_year: class_year }
+    def mock_params(class_year: '', to_add: '')
+      hash = { class_year: class_year, to_add: to_add }
       instance_spy('ActionController::Parameters', to_h: hash)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -151,21 +151,26 @@ RSpec.describe User, type: :model do
       result = user.restore_draw
       expect(result.draw_id).to eq(1234)
     end
-    it 'sets old_draw_id to nil' do
+    it 'sets draw_id to nil if old_draw_id and draw_id are equal' do
+      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 123)
+      result = user.restore_draw
+      expect(result.draw_id).to be_nil
+    end
+    it 'sets old_draw_id to nil by default' do
       user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234)
       result = user.restore_draw
-      expect(result.old_draw_id).to eq(nil)
+      expect(result.old_draw_id).to be_nil
+    end
+    it 'optionally saves draw_id to old_draw_id' do
+      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234)
+      result = user.restore_draw(save_current: true)
+      expect(result.old_draw_id).to eq(123)
     end
     it 'sets the intent to undeclared' do
       user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234,
                                               intent: 'on_campus')
       result = user.restore_draw
       expect(result.intent).to eq('undeclared')
-    end
-    it 'does nothing if old_draw_id is nil' do
-      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: nil)
-      result = user.restore_draw
-      expect(result).to eq(user)
     end
   end
 end


### PR DESCRIPTION
Resolves #171, resolves #172
- Add DrawStudentAssignmentForm form / service object for the addition and removal of individual students to draws
- Update User#restore_draw to optionally back up the current draw and avoid the edge case where the draw_id equals the old_draw_id

Blocked on #201 