### PR TITLE
FOR REFERENCE: [181] Add Suite deactivation/activation

### DIFF
--- a/app/assets/stylesheets/_draws.scss
+++ b/app/assets/stylesheets/_draws.scss
@@ -1,0 +1,2 @@
+@import "draws_suite_summary";
+@import "draws_student_summary";

--- a/app/assets/stylesheets/_draws_student_summary.scss
+++ b/app/assets/stylesheets/_draws_student_summary.scss
@@ -1,3 +1,17 @@
+.student-assignment {
+  @include grid-row;
+
+  .bulk, .single {
+    @include grid-column(12);
+    padding-bottom: 1em;
+
+    @include breakpoint(medium) {
+      @include grid-column(6);
+      padding-bottom: 0;
+    }
+  }
+}
+
 .students-list {
   @include grid-row;
 

--- a/app/assets/stylesheets/_draws_student_summary.scss
+++ b/app/assets/stylesheets/_draws_student_summary.scss
@@ -1,0 +1,12 @@
+.students-list {
+  @include grid-row;
+
+  .student-item {
+    @include grid-column(12);
+
+    @include breakpoint(medium) {
+      @include grid-column(3);
+      @include grid-column-end;
+    }
+  }
+}

--- a/app/assets/stylesheets/_draws_suite_summary.scss
+++ b/app/assets/stylesheets/_draws_suite_summary.scss
@@ -9,4 +9,9 @@
       @include grid-column-end;
     }
   }
+
+  a.draw-edit-suites {
+    font-family: $body-font-family;
+    font-size: 0.5em;
+  }
 }

--- a/app/assets/stylesheets/_draws_suite_summary.scss
+++ b/app/assets/stylesheets/_draws_suite_summary.scss
@@ -1,0 +1,12 @@
+.suites-list {
+  @include grid-row;
+
+  .suite-item {
+    @include grid-column(12);
+
+    @include breakpoint(medium) {
+      @include grid-column(3);
+      @include grid-column-end;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,4 +7,4 @@
 @import "flashes";
 @import "forms";
 @import "inline_checkboxes_override";
-@import "draws_suite_summary";
+@import "draws";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 @import "flashes";
 @import "forms";
 @import "inline_checkboxes_override";
+@import "draws_suite_summary";

--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -56,6 +56,6 @@ class DrawlessGroupsController < ApplicationController
     @group ||= Group.new
     @students = UngroupedStudentsQuery.call
     @leader_students = @group.members.empty? ? @students : @group.members
-    @suite_sizes = SuiteSizesQuery.call
+    @suite_sizes = SuiteSizesQuery.new(Suite.active).call
   end
 end

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -73,6 +73,23 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
     handle_action(**result)
   end
 
+  def student_summary
+    prepare_students_edit_data
+  end
+
+  def students_update
+    result = DrawStudentsUpdate.update(draw: @draw,
+                                       params: students_update_params)
+    @students_update = result[:update_object]
+    if @students_update
+      prepare_students_edit_data
+      result[:action] = 'student_summary'
+    else
+      result[:path] = draw_student_summary_path(@draw)
+    end
+    handle_action(**result)
+  end
+
   private
 
   def authorize!
@@ -92,6 +109,10 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
     params.require(:draw_suites_update).permit(:size, suite_ids: [],
                                                       drawn_suite_ids: [],
                                                       undrawn_suite_ids: [])
+  end
+
+  def students_update_params
+    params.require(:draw_students_update).permit(:class_year)
   end
 
   def filter_params
@@ -132,5 +153,11 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
                            .order(:number)
     @undrawn_suites = UndrawnSuitesQuery.new(base_suites).call
     @drawn_suites = DrawnSuitesForDrawQuery.new(base_suites).call(draw: @draw)
+  end
+
+  def prepare_students_edit_data
+    @students_update ||= DrawStudentsUpdate.new(draw: @draw)
+    @class_years = AvailableStudentClassYearsQuery.call
+    @students = @draw.students.order(:last_name)
   end
 end

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -53,8 +53,8 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
   end
 
   def suite_summary
-    @all_sizes = SuiteSizesQuery.call
-    @suites_by_size = SuitesBySizeQuery.new(@draw.suites).call
+    @all_sizes = SuiteSizesQuery.new(Suite.active).call
+    @suites_by_size = SuitesBySizeQuery.new(@draw.suites.active).call
   end
 
   def suites_edit
@@ -165,8 +165,8 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
 
   def calculate_oversub_metrics # rubocop:disable AbcSize
     return unless policy(@draw).oversub_report?
-    @suite_sizes = SuiteSizesQuery.new(@draw.suites).call
-    @suite_counts = @draw.suites.group(:size).count
+    @suite_sizes = SuiteSizesQuery.new(@draw.suites.active).call
+    @suite_counts = @draw.suites.active.group(:size).count
     zeroed_group_hash = @suite_sizes.map { |s| [s, 0] }.to_h
     @group_counts = zeroed_group_hash.merge(@draw.groups.group(:size).count)
     @locked_counts = @draw.groups.where(status: 'locked').group(:size).count
@@ -179,7 +179,7 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
     @suites_update ||= DrawSuitesUpdate.new(draw: @draw)
     @size = params[:size] ? params[:size].to_i : @suites_update.size
     base_suites = Suite.where(size: @size).available.order(:number)
-    @current_suites = @draw.suites.includes(:draws).where(size: @size)
+    @current_suites = @draw.suites.active.includes(:draws).where(size: @size)
                            .order(:number)
     @undrawn_suites = UndrawnSuitesQuery.new(base_suites).call
     @drawn_suites = DrawnSuitesForDrawQuery.new(base_suites).call(draw: @draw)

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 #
 # Controller for Draws
-class DrawsController < ApplicationController
+class DrawsController < ApplicationController # rubocop:disable ClassLength
   prepend_before_action :set_draw, except: %i(index new create)
   before_action :calculate_metrics, only: [:show, :activate]
 
@@ -57,6 +57,22 @@ class DrawsController < ApplicationController
     @suites_by_size = SuitesBySizeQuery.new(@draw.suites).call
   end
 
+  def suites_edit
+    prepare_suites_edit_data
+  end
+
+  def suites_update
+    result = DrawSuitesUpdate.update(draw: @draw, params: suites_update_params)
+    @suites_update = result[:update_object]
+    if @suites_update
+      prepare_suites_edit_data
+      result[:action] = 'suites_edit'
+    else
+      result[:path] = draw_suite_summary_path(@draw)
+    end
+    handle_action(**result)
+  end
+
   private
 
   def authorize!
@@ -70,6 +86,12 @@ class DrawsController < ApplicationController
   def draw_params
     params.require(:draw).permit(:name, :intent_deadline, suite_ids: [],
                                                           student_ids: [])
+  end
+
+  def suites_update_params
+    params.require(:draw_suites_update).permit(:size, suite_ids: [],
+                                                      drawn_suite_ids: [],
+                                                      undrawn_suite_ids: [])
   end
 
   def filter_params
@@ -100,5 +122,15 @@ class DrawsController < ApplicationController
     @diff = @suite_sizes.map do |size|
       [size, @suite_counts[size] - @group_counts[size]]
     end.to_h
+  end
+
+  def prepare_suites_edit_data # rubocop:disable AbcSize
+    @suites_update ||= DrawSuitesUpdate.new(draw: @draw)
+    @size = params[:size] ? params[:size].to_i : @suites_update.size
+    base_suites = Suite.where(size: @size).available.order(:number)
+    @current_suites = @draw.suites.includes(:draws).where(size: @size)
+                           .order(:number)
+    @undrawn_suites = UndrawnSuitesQuery.new(base_suites).call
+    @drawn_suites = DrawnSuitesForDrawQuery.new(base_suites).call(draw: @draw)
   end
 end

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -52,6 +52,11 @@ class DrawsController < ApplicationController
     render action: 'intent_report'
   end
 
+  def suite_summary
+    @all_sizes = SuiteSizesQuery.call
+    @suites_by_size = SuitesBySizeQuery.new(@draw.suites).call
+  end
+
   private
 
   def authorize!

--- a/app/controllers/suites_controller.rb
+++ b/app/controllers/suites_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 # Controller for Suites
 class SuitesController < ApplicationController
-  prepend_before_action :set_suite, only: %i(show edit update destroy)
+  prepend_before_action :set_suite, only: %i(show edit update destroy activate
+                                             deactivate)
 
   def show
     @rooms = @suite.rooms
@@ -30,6 +31,28 @@ class SuitesController < ApplicationController
   def destroy
     result = Destroyer.new(object: @suite, name_method: :number).destroy
     handle_action(**result)
+  end
+
+  def deactivate
+    if @suite.deactivate.save
+      flash[:success] = 'Suite successfully deactivated'
+      redirect_to(@suite)
+    else
+      errors = @suite.errors.full_messages.join(', ')
+      flash[:error] = "Suite could not be deactivated: #{errors}"
+      render 'show'
+    end
+  end
+
+  def activate
+    if @suite.activate.save
+      flash[:success] = 'Suite successfully activated'
+      redirect_to(@suite)
+    else
+      errors = @suite.errors.full_messages.join(', ')
+      flash[:error] = "Suite could not be activated: #{errors}"
+      render 'show'
+    end
   end
 
   private

--- a/app/forms/draw_student_assignment_form.rb
+++ b/app/forms/draw_student_assignment_form.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+#
+# Form / service object for adding or removing a single user to/from a draw by
+# username. Removes them from their current draw (if they belong to one) and
+# saves their previeous draw ID so they can be restored.
+class DrawStudentAssignmentForm
+  include ActiveModel::Model
+
+  attr_accessor :username, :adding
+
+  validates :username, presence: true
+  validates :adding, inclusion: { in: [true, false] }
+  validate :student_found
+  validate :student_valid
+
+  # Allows for calling :submit on the parent class
+  def self.submit(**params)
+    new(**params).submit
+  end
+
+  # Initializes a DrawStudentAssignmentForm
+  #
+  # @param params [#to_h] parameters from controller
+  def initialize(draw:, params: nil)
+    @draw = draw
+    @adding = true
+    process_params(params) if params
+  end
+
+  # Execute the student update, either adding or removing the student in
+  # question. If the username is invalid or belongs to a user in a group,
+  # returns an error.
+  #
+  # @return Hash{Symbol=>Nil,DrawStudentAssignmentForm,Hash} a result hash
+  #   containing nil for the :object, the DrawStudentAssignmentForm set to
+  #   :update_object if there were any failures, and a flash message
+  def submit
+    return error(error_msgs) unless valid?
+    if adding?
+      student.remove_draw.update!(draw_id: draw.id)
+    else
+      student.restore_draw(save_current: true).save!
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_reader :draw, :student
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @username = @params[:username]
+    @adding = @params[:adding] == 'true'
+    @student = find_student
+  end
+
+  def find_student
+    return nil unless username
+    UngroupedStudentsQuery.call.find_by(username: username)
+  end
+
+  def student_found
+    return if student
+    errors.add(:username, 'must belong to a student not in a group')
+  end
+
+  def student_valid
+    return unless student
+    validate_addition if adding?
+    validate_removal if removing?
+  end
+
+  def validate_addition
+    return unless student.draw_id == draw.id
+    errors.add(:username,
+               'must belong to a student outside the draw when adding')
+  end
+
+  def validate_removal
+    return unless student.draw_id != draw.id
+    errors.add(:username,
+               'must belong to a student in the draw when removing')
+  end
+
+  def error_msgs
+    errors.full_messages.join(', ')
+  end
+
+  def success
+    verb = adding? ? 'added' : 'removed'
+    {
+      object: nil, update_object: nil,
+      msg: { success: "#{student.full_name} successfully #{verb}" }
+    }
+  end
+
+  def error(error)
+    {
+      object: nil, update_object: self,
+      msg: { error: "Student update failed: #{error}" }
+    }
+  end
+
+  def adding?
+    adding
+  end
+
+  def removing?
+    !adding?
+  end
+end

--- a/app/helpers/suites_helper.rb
+++ b/app/helpers/suites_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+#
+# Helper module for Suites
+module SuitesHelper
+  # Generates a deactivation link for active suites and an activation link for
+  # inactive suites.
+  #
+  # @param suite [Suite] the suite in question
+  # @return [String] the appropriate link
+  def activation_link(suite)
+    action = suite.active? ? 'deactivate' : 'activate'
+    link_text = action.titleize
+    target_method = "#{action}_suite_path".to_sym
+    link_to link_text, send(target_method, suite), method: :patch
+  end
+end

--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -11,7 +11,8 @@
 class Draw < ApplicationRecord
   has_many :groups
   has_many :students, class_name: 'User'
-  has_and_belongs_to_many :suites # rubocop:disable Rails/HasAndBelongsToMany
+  has_many :draws_suites, dependent: :destroy
+  has_many :suites, through: :draws_suites
 
   validates :name, presence: true
   validates :status, presence: true

--- a/app/models/draw_students_update.rb
+++ b/app/models/draw_students_update.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+#
+# Form / service object to handle the updating of draw students
+class DrawStudentsUpdate
+  include ActiveModel::Model
+
+  attr_reader :class_year
+
+  # permit :update to be called on the parent class
+  def self.update(**params)
+    new(**params).update
+  end
+
+  # Initialize a new DrawStudentsUpdate
+  #
+  # @param draw [Draw] the draw to be updated
+  # @param params [#to_h] the parameters from the form
+  def initialize(draw:, params: nil)
+    @draw = draw
+    process_params(params) if params
+  end
+
+  # Execute the suites update, remove all suites to be removed and add all
+  # suites to be added. Occurs in a transaction for safety.
+  #
+  # @return [Hash{Symbol=>String,Hash,Nil,DrawStringUpdate] a result hash
+  #   containing the appropriate path to redirect to, a flash message to set,
+  #   and the DrawStudentsUpdate object if there were any failures.
+  def update
+    return no_action_warning if students_to_add.empty?
+    ActiveRecord::Base.transaction do
+      # update_all doesn't work since we have a left outer join in our ungrouped
+      # students query
+      students_to_add.each { |s| s.update(draw: draw) }
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_reader :draw, :params, :students_to_add
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @params[:class_year] = nil if @params[:class_year].empty?
+    @class_year = set_class_year
+    @students_to_add = find_students_to_add
+  end
+
+  def set_class_year
+    return nil unless params[:class_year]
+    params[:class_year].to_i
+  end
+
+  def find_students_to_add
+    return [] unless class_year
+    UngroupedStudentsQuery.call.where(draw_id: nil, class_year: class_year)
+  end
+
+  def no_action_warning
+    { object: nil, update_object: self, msg: { alert: 'No changes selected' } }
+  end
+
+  def success
+    {
+      object: nil, update_object: nil,
+      msg: { success: 'Students successfully updated' }
+    }
+  end
+
+  def error(error)
+    {
+      object: nil, update_object: self,
+      msg: { error: "Students update failed: #{error}" }
+    }
+  end
+end

--- a/app/models/draw_suites_update.rb
+++ b/app/models/draw_suites_update.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+#
+# Form / service object to handle the updating of draw suites
+class DrawSuitesUpdate
+  include ActiveModel::Model
+
+  attr_reader :size, :suite_ids, :drawn_suite_ids, :undrawn_suite_ids
+
+  # permit :update to be called on the parent class
+  def self.update(**params)
+    new(**params).update
+  end
+
+  # Initialize a new DrawSuitesUpdate
+  #
+  # @param draw [Draw] the draw to be updated
+  # @param params [#to_h] the parameters from the form
+  def initialize(draw:, params: nil)
+    @draw = draw
+    @suite_ids = draw.suite_ids
+    process_params(params) if params
+  end
+
+  # Execute the suites update, remove all suites to be removed and add all
+  # suites to be added. Occurs in a transaction for safety.
+  #
+  # @return [Hash{Symbol=>String,Hash,Nil,DrawStringUpdate] a result hash
+  #   containing the appropriate path to redirect to, a flash message to set,
+  #   and the DrawSuitesUpdate object if there were any failures.
+  def update
+    return no_action_warning if suites_to_remove.empty? && suites_to_add.empty?
+    ActiveRecord::Base.transaction do
+      remove_suites unless suites_to_remove.empty?
+      add_suites unless suites_to_add.empty?
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_reader :draw, :params, :suites_to_add, :suites_to_remove
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @size = extract_size
+    update_ids_param(:suite_ids)
+    update_ids_param(:drawn_suite_ids)
+    update_ids_param(:undrawn_suite_ids)
+    @suites_to_remove = find_suites_to_remove
+    @suites_to_add = find_suites_to_add
+  end
+
+  def extract_size
+    raise ArgumentError if size_param_not_an_int
+    params[:size].to_i
+  end
+
+  def size_param_not_an_int
+    params[:size].to_s.match(/\d+/).nil?
+  end
+
+  def update_ids_param(key)
+    params[key] = [] unless params[key]
+    @params[key] = params[key].reject(&:empty?)
+  end
+
+  def find_suites_to_remove
+    return [] unless params[:suite_ids]
+    # TODO: refactor not to require an extra db hit here, also makes testing
+    # better
+    current_suite_ids = draw.suites.where(size: size).map(&:id)
+    passed_suite_ids = params[:suite_ids].map(&:to_i)
+    Suite.find(current_suite_ids - passed_suite_ids)
+  end
+
+  def find_suites_to_add
+    return [] unless params[:drawn_suite_ids] || params[:undrawn_suite_ids]
+    Suite.find(params[:drawn_suite_ids] + params[:undrawn_suite_ids])
+  end
+
+  def remove_suites
+    suites_to_remove.each { |suite| draw.suites.destroy(suite) }
+  end
+
+  def add_suites
+    suites_to_add.each { |suite| draw.suites << suite }
+  end
+
+  def no_action_warning
+    { object: nil, update_object: self, msg: { alert: 'No changes selected' } }
+  end
+
+  def success
+    {
+      object: nil, update_object: nil,
+      msg: { success: 'Suites successfully updated' }
+    }
+  end
+
+  def error(error)
+    {
+      object: nil, update_object: self,
+      msg: { error: "Suites update failed: #{error}" }
+    }
+  end
+end

--- a/app/models/draws_suite.rb
+++ b/app/models/draws_suite.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+#
+# Intermediary model for draws <--> suites, originally a has_and_belongs_to_many
+# association but now has_many :through
+class DrawsSuite < ApplicationRecord
+  belongs_to :draw
+  belongs_to :suite
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -75,7 +75,7 @@ class Group < ApplicationRecord
     members << leader unless members.include? leader
   end
 
-  def validate_suite_size_inclusion
+  def validate_suite_size_inclusion # rubocop:disable AbcSize
     # TODO: if we start seeing this pattern (draw.present? branching logic) more
     # often then we can extract special group functionality into a subclass that
     # still talks to the same table in the db to keep things clean.
@@ -83,7 +83,7 @@ class Group < ApplicationRecord
       return if draw.suite_sizes.include? size
       errors.add :size, 'must be a suite size included in the draw'
     else
-      return if SuiteSizesQuery.call.include? size
+      return if SuiteSizesQuery.new(Suite.active).call.include? size
       errors.add :size, 'must be a valid suite size'
     end
   end

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -3,13 +3,14 @@
 # Model to represent the middle level of facility information
 # A suite is composed of mulitple rooms, which can be bedrooms or common rooms
 #
-# @attr [String] number The identifier of the Suite. Must be unique
-#   for Suites in the same Building.
-# @attr [Integer] size Counter cache of the total number of beds
-#   within the Suite's Rooms. Must be >= 0.
-# @attr [Building] building belongs_to association for the Building the
-#   Suite is located in.
-# @attr [Array<Room>] rooms has_many association for the Rooms within the Suite.
+# @attr number [String] The identifier of the Suite. Must be unique for Suites
+#   in the same Building.
+# @attr size [Integer] Counter cache of the total number of beds within the
+#   Suite's Rooms. Must be >= 0.
+# @attr building [Building] belongs_to association for the Building the Suite is
+#   located in.
+# @attr rooms [Array<Room>] has_many association for the Rooms within the Suite.
+# @attr active [Boolean] whether or not the suite is active
 class Suite < ApplicationRecord
   SIZE_STRS = { 1 => 'single', 2 => 'double', 3 => 'triple', 4 => 'quadruple',
                 5 => 'quintuple', 6 => 'sextuple', 7 => 'septuple',
@@ -25,7 +26,8 @@ class Suite < ApplicationRecord
   validates :size, presence: true,
                    numericality: { greater_than_or_equal_to: 0 }
 
-  scope :available, -> { where(group_id: nil).order(:number) }
+  scope :active, -> { where(active: true) }
+  scope :available, -> { where(group_id: nil).order(:number).active }
 
   # Return the equivalent string for a given suite size
   #
@@ -48,5 +50,21 @@ class Suite < ApplicationRecord
     return number if draws_to_display.empty?
     draws_str = draws_to_display.map(&:name).join(', ')
     "#{number} (#{draws_str})"
+  end
+
+  # Deactivate a suite (unpersisted).
+  #
+  # @return [Suite] the potentially deactivated suite
+  def deactivate
+    assign_attributes(active: false)
+    self
+  end
+
+  # Activate a suite (unpersisted).
+  #
+  # @return [Suite] the potentially activated suite
+  def activate
+    assign_attributes(active: true)
+    self
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,14 +99,18 @@ class User < ApplicationRecord
     self
   end
 
-  # Restores a user's draw from old_draw_id and clears old_draw_id, also setting
-  # intent to undeclared. Does nothing if old_draw_id is nil.
+  # Restores a user's draw from old_draw_id and optionally saves the current
+  # draw_id to old_draw_id, also setting intent to undeclared. If the draw_id is
+  # equal to the old_draw_id, will set draw_id to nil.
   #
+  # @param save_current [Boolean] whether or not to assign the current draw_id
+  #   value to old_draw_id, defaults to false
   # @return [User] the modified but unpersisted user object
-  def restore_draw
-    return self if old_draw_id.nil?
-    draw_id = old_draw_id
-    assign_attributes(draw_id: draw_id, old_draw_id: nil, intent: 'undeclared')
+  def restore_draw(save_current: false)
+    to_save = save_current ? draw_id : nil
+    new_draw_id = old_draw_id != draw_id ? old_draw_id : nil
+    assign_attributes(draw_id: new_draw_id, old_draw_id: to_save,
+                      intent: 'undeclared')
     self
   end
 

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -30,6 +30,14 @@ class DrawPolicy < ApplicationPolicy
     suites_edit?
   end
 
+  def student_summary?
+    edit?
+  end
+
+  def students_update?
+    edit?
+  end
+
   def group_actions?
     user.admin? || record.pre_lottery?
   end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -18,6 +18,10 @@ class DrawPolicy < ApplicationPolicy
     intent_report?
   end
 
+  def suite_summary?
+    show?
+  end
+
   def group_actions?
     user.admin? || record.pre_lottery?
   end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -22,6 +22,14 @@ class DrawPolicy < ApplicationPolicy
     show?
   end
 
+  def suites_edit?
+    edit?
+  end
+
+  def suites_update?
+    suites_edit?
+  end
+
   def group_actions?
     user.admin? || record.pre_lottery?
   end

--- a/app/policies/suite_policy.rb
+++ b/app/policies/suite_policy.rb
@@ -5,12 +5,24 @@ class SuitePolicy < ApplicationPolicy
     true
   end
 
-  def update?
+  def edit?
     user.rep? || user.admin?
+  end
+
+  def update?
+    edit?
   end
 
   def index?
     true
+  end
+
+  def deactivate?
+    edit?
+  end
+
+  def activate?
+    edit?
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/queries/available_student_class_years_query.rb
+++ b/app/queries/available_student_class_years_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+#
+# Query to return the class years of all students who are both not in a draw and
+# not in a group. This can be passed an existing relation for a subset of
+# students.
+class AvailableStudentClassYearsQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize an AvailableStudentClassYearsQuery
+  #
+  # @param relation [User::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = User.all)
+    @relation = relation
+  end
+
+  # Execute the class year query.
+  #
+  # @return [Array<Integer>] the valid class years
+  def call
+    UngroupedStudentsQuery.new(@relation).call.where(draw_id: nil)
+                          .map(&:class_year).uniq.sort
+  end
+end

--- a/app/queries/drawn_suites_for_draw_query.rb
+++ b/app/queries/drawn_suites_for_draw_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+#
+# Query to return the suites that belong to at least one draw, with the
+# exclusion of those that belong to the passed draw.
+class DrawnSuitesForDrawQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize an DrawnSuitesForDrawQuery
+  #
+  # @param relation [Suite::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the drawn suites query. Performs an left outer join with the
+  # draws_suites table. See http://stackoverflow.com/a/31524866 for more
+  # details.
+  #
+  # @param draw [Draw] the draw to exclude
+  # @return [Array<Suite>] the undrawn suites in the relation
+  def call(draw: nil)
+    base = @relation.includes(:draws).includes(:draws_suites)
+                    .where.not(draws_suites: { suite_id: nil })
+    return base unless draw
+    base.where.not(id: draw.suite_ids)
+  end
+end

--- a/app/queries/suites_by_size_query.rb
+++ b/app/queries/suites_by_size_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+#
+# Query to return all suites, collected by suite size, for a passed relation.
+# Defaults to all suites.
+class SuitesBySizeQuery
+  # See IntentMetricsQuery for explanation
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize a SuitesBySizeQuery
+  #
+  # @param relation [Suite::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the query
+  #
+  # @return [Hash{Integer=>Array<Suite>}] the suites in the relation collected
+  #   by size
+  def call
+    @relation.order(:number).group_by(&:size)
+  end
+end

--- a/app/queries/undrawn_suites_query.rb
+++ b/app/queries/undrawn_suites_query.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+#
+# Query to return the suites that don't belong to any draw. This can bee passed
+# an existing relation for a subset of all Suites.
+class UndrawnSuitesQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize an UndrawnSuitesQuery
+  #
+  # @param relation [Suite::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the undrawn suites query. Performs an left outer join with the
+  # draws_suites table. See http://stackoverflow.com/a/31524866 for more
+  # details.
+  #
+  # @return [Array<Suite>] the undrawn suites in the relation
+  def call
+    @relation.includes(:draws_suites).where(draws_suites: { suite_id: nil })
+  end
+end

--- a/app/queries/ungrouped_students_query.rb
+++ b/app/queries/ungrouped_students_query.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 #
 # Query to return the students who do not currently belong to any group, i.e. do
-#   belong to a membership. This can be passed an existing relation for a subset
-#   of all students.
+# belong to a membership. This can be passed an existing relation for a subset
+# of all students.
 class UngroupedStudentsQuery
   # See IntentMetricsQuery for explanation.
   class << self
@@ -18,12 +18,12 @@ class UngroupedStudentsQuery
   end
 
   # Execute the ungrouped students query. Filters students by role and performs
-  #   an inverse join with the memberships table. See
-  #   http://stackoverflow.com/a/9429191 for more details.
+  # a left outer join with the memberships table. See
+  # http://stackoverflow.com/a/31524866 for more details.
   #
   # @return [Array<User>] the ungrouped students in the relation
   def call
-    @relation.where(role: %w(student rep)).left_outer_joins(:membership)
+    @relation.where(role: %w(student rep)).includes(:membership)
              .where(memberships: { user_id: nil })
   end
 end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -34,4 +34,6 @@
 <% if policy(@draw).update? %>
   <p><%= link_to 'Add group to draw', new_draw_group_path(@draw) %></p>
 <% end %>
-<p><%= link_to 'Delete', draw_path(@draw), method: :delete %></p>
+<% if policy(@draw).destroy? %>
+  <p><%= link_to 'Delete', draw_path(@draw), method: :delete %></p>
+<% end %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -25,6 +25,9 @@
     <%= render 'oversub_report' %>
   </div>
 <% end %>
+<% if policy(@draw).student_summary? %>
+  <p><%= link_to 'View students', draw_student_summary_path(@draw) %></p>
+<% end %>
 <% if policy(@draw).suite_summary? %>
   <p><%= link_to 'View suites', draw_suite_summary_path(@draw) %></p>
 <% end %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -25,6 +25,9 @@
     <%= render 'oversub_report' %>
   </div>
 <% end %>
+<% if policy(@draw).suite_summary? %>
+  <p><%= link_to 'View suites', draw_suite_summary_path(@draw) %></p>
+<% end %>
 <% if policy(@draw).activate? %>
   <p><%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %></p>
 <% end %>

--- a/app/views/draws/student_summary.html.erb
+++ b/app/views/draws/student_summary.html.erb
@@ -1,17 +1,25 @@
 <h1 class="draw-name"><%= @draw.name %> Students</h1>
 <div class="student-assignment">
   <h2>Student actions</h2>
-  <% if @class_years.empty? %>
-    <p>There are no students available to add to this draw.</p>
-  <% else %>
-    <div class="bulk">
+  <div class="bulk">
+    <% if @available_students_count.zero? %>
+      <p>There are no students available to add to this draw.</p>
+    <% else %>
       <h3>Add students by class year</h3>
       <%= simple_form_for @students_update, url: draw_students_update_path(@draw), method: :patch do |f| %>
-        <%= f.input :class_year, as: :select, collection: @class_years %>
+        <%= f.input :class_year, as: :select, collection: @class_years, required: true %>
         <%= f.submit 'Assign students' %>
       <% end %>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
+  <div class="single">
+    <h3>Add student by username</h3>
+    <%= simple_form_for @student_assignment_form, url: draw_students_update_path(@draw), method: :patch do |f| %>
+      <%= f.input :username %>
+      <%= f.input :adding, label: 'Action', as: :radio_buttons, collection: [['Add', true], ['Remove', false]], required: true %>
+      <%= f.submit 'Update student' %>
+    <% end %>
+  </div>
 </div>
 <hr />
 <div class="students-list">

--- a/app/views/draws/student_summary.html.erb
+++ b/app/views/draws/student_summary.html.erb
@@ -1,0 +1,24 @@
+<h1 class="draw-name"><%= @draw.name %> Students</h1>
+<div class="student-assignment">
+  <h2>Student actions</h2>
+  <% if @class_years.empty? %>
+    <p>There are no students available to add to this draw.</p>
+  <% else %>
+    <div class="bulk">
+      <h3>Add students by class year</h3>
+      <%= simple_form_for @students_update, url: draw_students_update_path(@draw), method: :patch do |f| %>
+        <%= f.input :class_year, as: :select, collection: @class_years %>
+        <%= f.submit 'Assign students' %>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+<hr />
+<div class="students-list">
+  <h2>Students in draw</h2>
+  <% @students.each do |student| %>
+    <div class="student-item"><%= link_to student.full_name, user_path(student) %></div>
+  <% end %>
+</div>
+<hr />
+<%= link_to 'Return to draw', draw_path(@draw) %>

--- a/app/views/draws/suite_summary.html.erb
+++ b/app/views/draws/suite_summary.html.erb
@@ -1,11 +1,10 @@
 <h1 class="draw-name"><%= @draw.name %> Suites</h1>
 <% @all_sizes.each do |size| %>
-  <div class="suites-<%= size_str(size).pluralize %>">
+  <div class="suites-list suites-<%= size_str(size).pluralize %>">
     <h2><%= size_str(size).pluralize.titleize %></h2>
-    <p><%= link_to 'Update', draw_suites_update_path(@draw, size), id: "update-suites-#{size}" %></p>
     <% if @suites_by_size.has_key? size %>
       <% @suites_by_size[size].each do |suite| %>
-        <div class="suite-item"><%= suite.number %></div>
+        <div class="suite-item"><%= link_to suite.number, suite_path(suite) %></div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/draws/suite_summary.html.erb
+++ b/app/views/draws/suite_summary.html.erb
@@ -1,7 +1,7 @@
 <h1 class="draw-name"><%= @draw.name %> Suites</h1>
 <% @all_sizes.each do |size| %>
   <div class="suites-list suites-<%= size_str(size).pluralize %>">
-    <h2><%= size_str(size).pluralize.titleize %></h2>
+    <h2><%= size_str(size).pluralize.titleize %> <%= link_to 'Edit', draw_suites_edit_path(@draw, size), id: "edit-suites-#{size}", clasS: 'draw-edit-suites' if policy(@draw).suites_edit? %></h2>
     <% if @suites_by_size.has_key? size %>
       <% @suites_by_size[size].each do |suite| %>
         <div class="suite-item"><%= link_to suite.number, suite_path(suite) %></div>

--- a/app/views/draws/suites_edit.html.erb
+++ b/app/views/draws/suites_edit.html.erb
@@ -1,0 +1,9 @@
+<h1 class="draw-name"><%= @draw.name %> <%= size_str(@size).pluralize.titleize %></h1>
+<%= simple_form_for @suites_update, url: draw_suites_update_path(@draw), method: :patch do |f| %>
+  <%= f.input :suite_ids, label: 'Current suites', as: :check_boxes, label_method: ->(s) { s.number_with_draws(@draw) }, collection: @current_suites unless @current_suites.empty? %>
+  <%= f.input :undrawn_suite_ids, label: 'Suites not in draws', as: :check_boxes, label_method: :number, collection: @undrawn_suites unless @undrawn_suites.empty? %>
+  <%= f.input :drawn_suite_ids, label: 'Suites in other draws', as: :check_boxes, label_method: :number_with_draws, collection: @drawn_suites unless @drawn_suites.empty? %>
+  <%= f.input :size, as: :hidden, input_html: { value: @size } %>
+  <%= f.submit 'Update' %>
+<% end %>
+<%= link_to 'Back to suite summary', draw_suite_summary_path(@draw) %>

--- a/app/views/draws/suites_edit.html.erb
+++ b/app/views/draws/suites_edit.html.erb
@@ -6,4 +6,5 @@
   <%= f.input :size, as: :hidden, input_html: { value: @size } %>
   <%= f.submit 'Update' %>
 <% end %>
+<hr />
 <%= link_to 'Back to suite summary', draw_suite_summary_path(@draw) %>

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,12 +1,12 @@
 <div class="form-inputs">
-	<%= f.input :size, collection: @suite_sizes %>
-	<% if current_user.admin? %>
-	  <%= f.association :leader, label_method: :full_name, collection: @leader_students %>
-    <%= f.input :remove_ids, label: 'Users to remove', collection: @group.removable_members, label_method: :full_name, as: :check_boxes %>
-	  <%= f.input :member_ids, :label => 'User to add', label_method: :full_name, as: :check_boxes, collection: @students %>
-	<% end %>
+  <%= f.input :size, collection: @suite_sizes %>
+  <% if current_user.admin? %>
+    <%= f.association :leader, label_method: :full_name, collection: @leader_students %>
+    <%= f.input :remove_ids, label: 'Users to remove', collection: @group.removable_members, label_method: :full_name, as: :check_boxes unless @group.removable_members.empty? %>
+    <%= f.input :member_ids, label: 'Users to add', label_method: :full_name, as: :check_boxes, collection: @students %>
+  <% end %>
 </div>
 
 <div class="form-actions">
-	<%= f.button :submit %>
+  <%= f.button :submit %>
 </div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,5 +1,5 @@
 <h1> New Group </h1>
-  <%= render "form", group: @group %>
+<%= render "form", group: @group %>
 
 <% content_for :sidebar do %>
   <h2>Insert Draw Inventory here</h2>

--- a/app/views/suites/show.html.erb
+++ b/app/views/suites/show.html.erb
@@ -6,5 +6,6 @@
   <% end %>
 </ul>
 <p><%= link_to 'Add room', new_room_path %></p>
+<p><%= activation_link(@suite) %></p>
 <p><%= link_to 'Delete', suite_path(@suite), method: :delete %></p>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,9 +20,11 @@ module Vesta
     services_paths = %w(creators updaters destroyers).map do |s|
       "/app/services/#{s}"
     end
+    forms_path = %w(/app/forms)
     lib_paths = %w(seed).map { |s| "/lib/#{s}" }
-    config.autoload_paths += (services_paths + lib_paths + %w(/lib/)).map do |s|
-      "#{config.root}#{s}"
-    end
+    config.autoload_paths +=
+      (services_paths + forms_path + lib_paths + %w(/lib/)).map do |s|
+        "#{config.root}#{s}"
+      end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   get 'draws/:id/intent_report', to: 'draws#intent_report',
                                  as: 'draw_intent_report'
   post 'draws/:id/intent_report', to: 'draws#filter_intent_report'
+  get 'draws/:id/suites', to: 'draws#suite_summary', as: 'draw_suite_summary'
 
   resources :groups, controller: 'drawless_groups'
   patch 'groups/:id/select_suite', to: 'drawless_groups#select_suite',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
                                  as: 'draw_intent_report'
   post 'draws/:id/intent_report', to: 'draws#filter_intent_report'
   get 'draws/:id/suites', to: 'draws#suite_summary', as: 'draw_suite_summary'
+  get 'draws/:id/suites/:size', to: 'draws#suites_edit', as: 'draw_suites_edit'
+  patch 'draws/:id/suites', to: 'draws#suites_update', as: 'draw_suites_update'
 
   resources :groups, controller: 'drawless_groups'
   patch 'groups/:id/select_suite', to: 'drawless_groups#select_suite',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   root to: 'application#home'
   resources :buildings
   resources :suites
+  patch '/suites/:id/deactivate', to: 'suites#deactivate',
+                                  as: 'deactivate_suite'
+  patch '/suites/:id/activate', to: 'suites#activate', as: 'activate_suite'
   resources :rooms
   get 'users/build', to: 'users#build', as: 'build_user'
   resources :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,10 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   get 'draws/:id/suites', to: 'draws#suite_summary', as: 'draw_suite_summary'
   get 'draws/:id/suites/:size', to: 'draws#suites_edit', as: 'draw_suites_edit'
   patch 'draws/:id/suites', to: 'draws#suites_update', as: 'draw_suites_update'
+  get 'draws/:id/students', to: 'draws#student_summary',
+                            as: 'draw_student_summary'
+  patch 'draws/:id/students', to: 'draws#students_update',
+                              as: 'draw_students_update'
 
   resources :groups, controller: 'drawless_groups'
   patch 'groups/:id/select_suite', to: 'drawless_groups#select_suite',

--- a/db/migrate/20170217030248_add_active_to_suites.rb
+++ b/db/migrate/20170217030248_add_active_to_suites.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddActiveToSuites < ActiveRecord::Migration[5.0]
+  def change
+    add_column :suites, :active, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208040633) do
+ActiveRecord::Schema.define(version: 20170217030248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,11 +84,12 @@ ActiveRecord::Schema.define(version: 20170208040633) do
 
   create_table "suites", force: :cascade do |t|
     t.integer  "building_id"
-    t.string   "number",                  null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.integer  "size",        default: 0, null: false
+    t.string   "number",                     null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "size",        default: 0,    null: false
     t.integer  "group_id"
+    t.boolean  "active",      default: true, null: false
     t.index ["building_id"], name: "index_suites_on_building_id", using: :btree
     t.index ["group_id"], name: "index_suites_on_group_id", using: :btree
   end

--- a/spec/features/draws/draw_student_assignment_spec.rb
+++ b/spec/features/draws/draw_student_assignment_spec.rb
@@ -19,4 +19,32 @@ RSpec.feature 'Draw student assignment' do
       click_on 'Assign students'
     end
   end
+
+  describe 'single user adding' do
+    let!(:student) { FactoryGirl.create(:student, username: 'foo') }
+    it 'can be performed' do
+      visit draw_student_summary_path(draw)
+      fill_in 'draw_student_assignment_form_username', with: 'foo'
+      click_on 'Update student'
+      message = "#{student.full_name} successfully added"
+      expect(page).to have_css('.flash-success', text: message)
+    end
+  end
+
+  describe 'single user removing' do
+    let(:student) { FactoryGirl.create(:student, username: 'foo') }
+    before { draw.students << student }
+    it 'can be performed' do
+      visit draw_student_summary_path(draw)
+      remove_user(username: 'foo')
+      message = "#{student.full_name} successfully removed"
+      expect(page).to have_css('.flash-success', text: message)
+    end
+
+    def remove_user(username:)
+      fill_in 'draw_student_assignment_form_username', with: username
+      choose 'Remove'
+      click_on 'Update student'
+    end
+  end
 end

--- a/spec/features/draws/draw_student_assignment_spec.rb
+++ b/spec/features/draws/draw_student_assignment_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw student assignment' do
+  let(:draw) { FactoryGirl.create(:draw) }
+  before { log_in FactoryGirl.create(:admin) }
+  describe 'bulk adding' do
+    before { FactoryGirl.create_pair(:student, class_year: 2016) }
+    it 'can be performed' do
+      visit draw_path(draw)
+      click_on 'View student'
+      bulk_assign_students(2016)
+      message = 'Students successfully updated'
+      expect(page).to have_css('.flash-success', text: message)
+    end
+
+    def bulk_assign_students(year)
+      select year.to_s, from: 'draw_students_update_class_year'
+      click_on 'Assign students'
+    end
+  end
+end

--- a/spec/features/draws/draw_suite_summary_spec.rb
+++ b/spec/features/draws/draw_suite_summary_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw suite summary' do
+  let(:draw) { FactoryGirl.create(:draw_with_members, suites_count: 1) }
+  let(:draw_suite) { draw.suites.first }
+  let(:other_suite) { FactoryGirl.create(:suite) }
+
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'displays correctly' do
+    visit draw_path(draw)
+    click_on 'View suites'
+    expect(page_has_suite_summary?(page, draw_suite, other_suite)).to be_truthy
+  end
+
+  def page_has_suite_summary?(page, draw_suite, other_suite)
+    page_has_suite_content?(page, draw_suite) &&
+      page_does_not_have_suite_content?(page, other_suite)
+  end
+
+  def page_has_suite_content?(page, suite)
+    page.assert_selector(:css, '.suite-item a', text: suite.number)
+  end
+
+  def page_does_not_have_suite_content?(page, suite)
+    page.refute_selector(:css, '.suite-item a', text: suite.number)
+  end
+end

--- a/spec/features/draws/draw_suite_update_spec.rb
+++ b/spec/features/draws/draw_suite_update_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw suite update' do
+  let(:draw) { FactoryGirl.create(:draw_with_members, suites_count: 1) }
+  let!(:removed_suite) { draw.suites.first }
+  let(:other_draw) { FactoryGirl.create(:draw_with_members, suites_count: 1) }
+  let!(:other_draw_suite) { other_draw.suites.first }
+  let!(:undrawn_suite) { FactoryGirl.create(:suite_with_rooms, rooms_count: 1) }
+
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be performed' do
+    visit_update_suite_page
+    update_suites
+    click_on 'Update'
+    expected_suites = [other_draw_suite, undrawn_suite]
+    expect(page_has_correct_suites(page, expected_suites)).to be_truthy
+  end
+
+  def visit_update_suite_page
+    visit draw_path(draw)
+    click_on 'View suites'
+    click_on 'edit-suites-1'
+  end
+
+  def update_suites
+    remove_suite(removed_suite)
+    add_drawn_suite(other_draw_suite)
+    add_undrawn_suite(undrawn_suite)
+  end
+
+  def remove_suite(suite)
+    uncheck suite.number
+  end
+
+  def add_drawn_suite(suite)
+    check suite.number_with_draws
+  end
+
+  def add_undrawn_suite(suite)
+    check suite.number
+  end
+
+  def page_has_correct_suites(page, expected_suites)
+    expected_suites.all? do |suite|
+      page.assert_selector(:css, '.suite-item a', text: suite.number)
+    end
+  end
+end

--- a/spec/features/suites/suite_activation_spec.rb
+++ b/spec/features/suites/suite_activation_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Suite activation' do
+  let(:suite) { FactoryGirl.create(:suite, active: false) }
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be performed' do
+    visit suite_path(suite)
+    click_on 'Activate'
+    expect(page).to \
+      have_css('.flash-success', text: 'Suite successfully activated')
+  end
+end

--- a/spec/features/suites/suite_deactivation_spec.rb
+++ b/spec/features/suites/suite_deactivation_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Suite deactivation' do
+  let(:suite) { FactoryGirl.create(:suite, active: true) }
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be performed' do
+    visit suite_path(suite)
+    click_on 'Deactivate'
+    expect(page).to \
+      have_css('.flash-success', text: 'Suite successfully deactivated')
+  end
+end

--- a/spec/forms/draw_student_assignment_form_spec.rb
+++ b/spec/forms/draw_student_assignment_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawStudentAssignmentForm, type: :model do
+  let(:draw) { FactoryGirl.create(:draw) }
+  describe '.submit' do
+    xit 'allows for :submit to be called on the parent class'
+  end
+
+  describe 'validations' do
+    subject(:form_object) { described_class.new(draw: draw) }
+    it { is_expected.to validate_presence_of(:username) }
+    # commenting this out due to a shoulda_matchers warning
+    # it do
+    #   is_expected.to validate_inclusion_of(:adding).in_array([true, false])
+    # end
+    it 'validates that a valid student is found' do
+      klass = 'User::ActiveRecord_Relation'
+      allow(UngroupedStudentsQuery).to receive(:call)
+        .and_return(instance_spy(klass, find_by: nil))
+      expect(form_object.valid?).to be_falsey
+    end
+  end
+
+  describe '#submit' do
+    context 'adding a user success' do
+      it 'takes a username and adds the user' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        expect { described_class.submit(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(1)
+      end
+      it 'ignores grouped users' do
+        FactoryGirl.create(:drawless_group).leader.update(username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        expect { described_class.submit(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(0)
+      end
+      it 'sets :object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:update_object]).to be_nil
+      end
+      it 'sets a success message' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: 'foo', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:success)
+      end
+    end
+
+    context 'failure' do
+      it 'sets :object as nil' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the form object' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        object = described_class.new(draw: draw, params: params)
+        expect(object.submit[:update_object]).to eq(object)
+      end
+      it 'sets an error message' do
+        FactoryGirl.create(:student, username: 'foo')
+        params = mock_params(username: '', adding: 'true')
+        result = described_class.submit(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+    end
+
+    def mock_params(username: '', adding: nil)
+      hash = { username: username, adding: adding }
+      instance_spy('ActionController::Parameters', to_h: hash)
+    end
+  end
+end

--- a/spec/helpers/suites_helper_spec.rb
+++ b/spec/helpers/suites_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuitesHelper do
+  describe '#activation_link' do
+    it 'displays a link to deactivate the suite if active' do
+      suite = FactoryGirl.build(:suite, id: 123, active: true)
+      result = helper.activation_link(suite)
+      string_to_match = "/suites/#{suite.id}/deactivate"
+      expect(result).to match(/#{Regexp.escape(string_to_match)}/)
+    end
+    it 'displays a link to activate the suite if inactive' do
+      suite = FactoryGirl.build(:suite, id: 123, active: false)
+      result = helper.activation_link(suite)
+      string_to_match = "/suites/#{suite.id}/activate"
+      expect(result).to match(/#{Regexp.escape(string_to_match)}/)
+    end
+  end
+end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Draw, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to have_many(:students) }
     it { is_expected.to have_many(:groups) }
-    it { is_expected.to have_and_belong_to_many(:suites) }
+    it { is_expected.to have_many(:draws_suites) }
+    it { is_expected.to have_many(:suites).through(:draws_suites) }
     it { is_expected.to validate_presence_of(:status) }
   end
 

--- a/spec/models/draw_students_update_spec.rb
+++ b/spec/models/draw_students_update_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawStudentsUpdate do
+  describe '.update' do
+    xit 'calls :update on a new instance of DrawStudentsUpdate' do
+    end
+  end
+
+  describe '#update' do
+    context 'success' do
+      it 'bulk-adds users of a passed class year' do
+        draw = FactoryGirl.create(:draw)
+        FactoryGirl.create(:student, class_year: 2016)
+        params = mock_params(class_year: '2016')
+        expect { described_class.update(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(1)
+      end
+      it 'ignores students that are in other draws or groups' do
+        draw = FactoryGirl.create(:draw)
+        create_students_in_year(2016)
+        params = mock_params(class_year: '2016')
+        expect { described_class.update(draw: draw, params: params) }.to \
+          change { draw.students.count }.by(1)
+      end
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw)
+        FactoryGirl.create(:student, class_year: 2016)
+        params = mock_params(class_year: '2016')
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to nil' do
+        draw = FactoryGirl.create(:draw)
+        FactoryGirl.create(:student, class_year: 2016)
+        params = mock_params(class_year: '2016')
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:update_object]).to be_nil
+      end
+      it 'sets a success message' do
+        draw = FactoryGirl.create(:draw)
+        FactoryGirl.create(:student, class_year: 2016)
+        params = mock_params(class_year: '2016')
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:success)
+      end
+      def create_students_in_year(year)
+        FactoryGirl.create(:student_in_draw, class_year: year)
+        student_in_group = FactoryGirl.create(:drawless_group).leader
+        student_in_group.update(class_year: year)
+        FactoryGirl.create(:student, class_year: year)
+      end
+    end
+
+    context 'warning' do
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw)
+        result = described_class.update(draw: draw, params: mock_params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the update object' do
+        draw = FactoryGirl.create(:draw)
+        update_object = described_class.new(draw: draw, params: mock_params)
+        expect(update_object.update[:update_object]).to eq(update_object)
+      end
+      it 'sets an alert message' do
+        draw = FactoryGirl.create(:draw)
+        result = described_class.update(draw: draw, params: mock_params)
+        expect(result[:msg]).to have_key(:alert)
+      end
+    end
+
+    context 'error' do
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw)
+        bad_user = create_bad_user
+        params = mock_params(class_year: bad_user.class_year.to_s)
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the update object' do
+        draw = FactoryGirl.create(:draw)
+        bad_user = create_bad_user
+        params = mock_params(class_year: bad_user.class_year.to_s)
+        update_object = described_class.new(draw: draw, params: params)
+        expect(update_object.update[:update_object]).to eq(update_object)
+      end
+      it 'sets an error message' do
+        draw = FactoryGirl.create(:draw)
+        bad_user = create_bad_user
+        params = mock_params(class_year: bad_user.class_year.to_s)
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+
+      def create_bad_user
+        klass = 'User::ActiveRecord_Relation'
+        FactoryGirl.create(:student, class_year: 2016).tap do |s|
+          allow(UngroupedStudentsQuery).to receive(:call)
+            .and_return(instance_spy(klass, where: [s]))
+          allow(s).to receive(:update).and_raise(ActiveRecord::RecordInvalid)
+        end
+      end
+    end
+
+    def mock_params(class_year: '')
+      hash = { class_year: class_year }
+      instance_spy('ActionController::Parameters', to_h: hash)
+    end
+  end
+end

--- a/spec/models/draw_students_update_spec.rb
+++ b/spec/models/draw_students_update_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe DrawStudentsUpdate do
       it 'bulk-adds users of a passed class year' do
         draw = FactoryGirl.create(:draw)
         FactoryGirl.create(:student, class_year: 2016)
-        params = mock_params(class_year: '2016')
+        params = mock_params(class_year: '2016', to_add: nil)
         expect { described_class.update(draw: draw, params: params) }.to \
           change { draw.students.count }.by(1)
       end
       it 'ignores students that are in other draws or groups' do
         draw = FactoryGirl.create(:draw)
         create_students_in_year(2016)
-        params = mock_params(class_year: '2016')
+        params = mock_params(class_year: '2016', to_add: nil)
         expect { described_class.update(draw: draw, params: params) }.to \
           change { draw.students.count }.by(1)
       end
@@ -103,8 +103,8 @@ RSpec.describe DrawStudentsUpdate do
       end
     end
 
-    def mock_params(class_year: '')
-      hash = { class_year: class_year }
+    def mock_params(class_year: '', to_add: '')
+      hash = { class_year: class_year, to_add: to_add }
       instance_spy('ActionController::Parameters', to_h: hash)
     end
   end

--- a/spec/models/draw_suites_update_spec.rb
+++ b/spec/models/draw_suites_update_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawSuitesUpdate do
+  describe '.update' do
+    xit 'calls :update on a new instance of DrawSuitesUpdate' do
+    end
+  end
+
+  describe '#new' do
+    it 'raises with an invalid size parameter' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      params = instance_spy('ActionController::Parameters', to_h: { size: nil })
+      expect { described_class.new(draw: draw, params: params) }.to \
+        raise_error(ArgumentError)
+    end
+  end
+
+  describe '#update' do
+    context 'success' do
+      it 'removes current suites of the correct size' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        draw.suites << FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+        params = mock_params(suite_ids: [])
+        expect { described_class.update(draw: draw, params: params) }.to \
+          change { draw.suites.count }.by(-1)
+      end
+      # rubocop:disable RSpec/ExampleLength
+      it 'adds suites from both drawn_suite_ids and undrawn_suite_ids' do
+        draw = FactoryGirl.create(:draw)
+        undrawn_suite = FactoryGirl.create(:suite)
+        drawn_suite = create_drawn_suite
+        params = mock_params(drawn_suite_ids: [drawn_suite.id.to_s],
+                             undrawn_suite_ids: [undrawn_suite.id.to_s])
+        expect { described_class.update(draw: draw, params: params) }.to \
+          change { draw.suites.count }.by(2)
+      end
+      # rubocop:enable RSpec/ExampleLength
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        params = mock_params(suite_ids: [])
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to nil' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        params = mock_params(suite_ids: [])
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:update_object]).to be_nil
+      end
+      it 'sets a success message' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        params = mock_params(suite_ids: [])
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:success)
+      end
+    end
+
+    context 'warning' do
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw)
+        result = described_class.update(draw: draw, params: mock_params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the update object' do
+        draw = FactoryGirl.create(:draw)
+        update_object = described_class.new(draw: draw, params: mock_params)
+        expect(update_object.update[:update_object]).to eq(update_object)
+      end
+      it 'sets an alert message' do
+        draw = FactoryGirl.create(:draw)
+        result = described_class.update(draw: draw, params: mock_params)
+        expect(result[:msg]).to have_key(:alert)
+      end
+    end
+
+    context 'error' do
+      it 'sets :object to nil' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        allow(draw).to receive(:suites).and_return(broken_suites)
+        params = mock_params(suite_ids: [])
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'sets :update_object to the update object' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        allow(draw).to receive(:suites).and_return(broken_suites)
+        params = mock_params(suite_ids: [])
+        update_object = described_class.new(draw: draw, params: params)
+        expect(update_object.update[:update_object]).to eq(update_object)
+      end
+      it 'sets an error message' do
+        draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+        allow(draw).to receive(:suites).and_return(broken_suites)
+        params = mock_params(suite_ids: [])
+        result = described_class.update(draw: draw, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+
+      def broken_suites
+        klass = 'Suite::ActiveRecord_Associations_CollectionProxy'
+        instance_spy(klass).tap do |s|
+          allow(s).to receive(:destroy).and_raise(ActiveRecord::RecordInvalid)
+          # this is necessary to get through the #find_suites_to_remove private
+          # method, which will ideally be refactored eventually
+          allow(s).to receive(:where).and_return([Suite.last])
+        end
+      end
+    end
+
+    def mock_params(suite_ids: nil, drawn_suite_ids: nil,
+                    undrawn_suite_ids: nil)
+      # takes the default size from the factory :draw_with_members /
+      # :suites_with_rooms
+      hash = { suite_ids: suite_ids, drawn_suite_ids: drawn_suite_ids,
+               undrawn_suite_ids: undrawn_suite_ids, size: '1' }
+      instance_spy('ActionController::Parameters', to_h: hash)
+    end
+
+    def create_drawn_suite
+      draw = FactoryGirl.create(:draw_with_members, suites_count: 1)
+      draw.suites.first
+    end
+  end
+end

--- a/spec/models/draws_suite_spec.rb
+++ b/spec/models/draws_suite_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawsSuite do
+  describe 'associations' do
+    subject { described_class.new }
+    it { is_expected.to belong_to(:draw) }
+    it { is_expected.to belong_to(:suite) }
+  end
+end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Suite, type: :model do
   end
 
   context 'scopes' do
+    describe '.active' do
+      it 'returns all suites that are active' do
+        suite = FactoryGirl.create(:suite, active: true)
+        FactoryGirl.create(:suite, active: false)
+        expect(described_class.available.map(&:id)).to \
+          eq([suite.id])
+      end
+    end
+
     describe '.available' do
       it 'returns all suites not assigned to groups ordered by number' do
         suite1 = FactoryGirl.create(:suite, number: 'def')
@@ -34,6 +43,13 @@ RSpec.describe Suite, type: :model do
         FactoryGirl.create(:suite, group_id: 1234)
         expect(described_class.available.map(&:id)).to \
           eq([suite2.id, suite1.id])
+      end
+      it 'returns only active suites' do
+        suite = FactoryGirl.create(:suite, number: 'def', active: true)
+        FactoryGirl.create(:suite, number: 'abc', active: false)
+        FactoryGirl.create(:suite, group_id: 1234)
+        expect(described_class.available.map(&:id)).to \
+          eq([suite.id])
       end
     end
   end
@@ -98,6 +114,20 @@ RSpec.describe Suite, type: :model do
       draw2 = FactoryGirl.create(:draw)
       expected = "#{draw.suites.first.number} (#{draw.name})"
       expect(draw.suites.first.number_with_draws(draw2)).to eq(expected)
+    end
+  end
+
+  describe '#deactivate' do
+    it 'returns an inactive suite' do
+      suite = FactoryGirl.build_stubbed(:suite, active: true)
+      expect(suite.deactivate).not_to be_active
+    end
+  end
+
+  describe '#activate' do
+    it 'returns an active suite' do
+      suite = FactoryGirl.build_stubbed(:suite, active: false)
+      expect(suite.activate).to be_active
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -151,21 +151,26 @@ RSpec.describe User, type: :model do
       result = user.restore_draw
       expect(result.draw_id).to eq(1234)
     end
-    it 'sets old_draw_id to nil' do
+    it 'sets draw_id to nil if old_draw_id and draw_id are equal' do
+      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 123)
+      result = user.restore_draw
+      expect(result.draw_id).to be_nil
+    end
+    it 'sets old_draw_id to nil by default' do
       user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234)
       result = user.restore_draw
-      expect(result.old_draw_id).to eq(nil)
+      expect(result.old_draw_id).to be_nil
+    end
+    it 'optionally saves draw_id to old_draw_id' do
+      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234)
+      result = user.restore_draw(save_current: true)
+      expect(result.old_draw_id).to eq(123)
     end
     it 'sets the intent to undeclared' do
       user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: 1234,
                                               intent: 'on_campus')
       result = user.restore_draw
       expect(result.intent).to eq('undeclared')
-    end
-    it 'does nothing if old_draw_id is nil' do
-      user = FactoryGirl.build_stubbed(:user, draw_id: 123, old_draw_id: nil)
-      result = user.restore_draw
-      expect(result).to eq(user)
     end
   end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe DrawPolicy do
       it { is_expected.to permit(user, draw) }
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
-                :intent_report?, :filter_intent_report? do
+                :intent_report?, :filter_intent_report?, :suites_edit?,
+                :suites_update? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -69,7 +70,8 @@ RSpec.describe DrawPolicy do
       it { is_expected.to permit(user, draw) }
     end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
-                :intent_report?, :filter_intent_report? do
+                :intent_report?, :filter_intent_report?, :suites_edit?,
+                :suites_update? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :index? do
@@ -123,7 +125,8 @@ RSpec.describe DrawPolicy do
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
-                :filter_intent_report?, :group_actions?, :suite_summary? do
+                :filter_intent_report?, :group_actions?, :suite_summary?,
+                :suites_edit?, :suites_update? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index?, :new?, :create? do

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DrawPolicy do
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
-                :suites_update? do
+                :suites_update?, :student_summary?, :students_update? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -71,7 +71,7 @@ RSpec.describe DrawPolicy do
     end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
-                :suites_update? do
+                :suites_update?, :student_summary?, :students_update? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :index? do
@@ -126,7 +126,8 @@ RSpec.describe DrawPolicy do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
                 :filter_intent_report?, :group_actions?, :suite_summary?,
-                :suites_edit?, :suites_update? do
+                :suites_edit?, :suites_update?, :student_summary?,
+                :students_update? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index?, :new?, :create? do

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DrawPolicy do
 
   context 'student' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
-    permissions :show? do
+    permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
@@ -65,7 +65,7 @@ RSpec.describe DrawPolicy do
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show? do
+    permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
@@ -123,7 +123,7 @@ RSpec.describe DrawPolicy do
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
-                :filter_intent_report?, :group_actions? do
+                :filter_intent_report?, :group_actions?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index?, :new?, :create? do

--- a/spec/policies/suite_policy_spec.rb
+++ b/spec/policies/suite_policy_spec.rb
@@ -13,30 +13,31 @@ RSpec.describe SuitePolicy do
     permissions :index? do
       it { is_expected.to permit(user, Suite) }
     end
-    permissions :create?, :destroy?, :edit?, :update? do
+    permissions :new?, :create?, :destroy?, :edit?, :update?, :deactivate?,
+                :activate? do
       it { is_expected.not_to permit(user, suite) }
     end
   end
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show?, :edit?, :update? do
+    permissions :show?, :edit?, :update?, :deactivate?, :activate? do
       it { is_expected.to permit(user, suite) }
     end
     permissions :index? do
       it { is_expected.to permit(user, Suite) }
     end
-    permissions :create?, :destroy? do
+    permissions :new?, :create?, :destroy? do
       it { is_expected.not_to permit(user, suite) }
     end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :show?, :edit?, :update?, :create?, :destroy? do
+    permissions :show?, :edit?, :update?, :destroy?, :deactivate?, :activate? do
       it { is_expected.to permit(user, suite) }
     end
-    permissions :index? do
+    permissions :new?, :create?, :index? do
       it { is_expected.to permit(user, Suite) }
     end
   end

--- a/spec/queries/available_student_class_years_query_spec.rb
+++ b/spec/queries/available_student_class_years_query_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AvailableStudentClassYearsQuery do
+  describe '#call' do
+    it 'finds all the class years of available students' do
+      FactoryGirl.create(:student, class_year: 2016)
+      FactoryGirl.create(:student_in_draw, class_year: 2017)
+      FactoryGirl.create(:drawless_group).leader.update(class_year: 2018)
+      expect(described_class.call).to eq([2016])
+    end
+    it 'ignores duplicates' do
+      FactoryGirl.create_pair(:student, class_year: 2016)
+      expect(described_class.call).to eq([2016])
+    end
+    it 'takes a relation in the constructor to limit the query' do
+      FactoryGirl.create(:student, class_year: 2016)
+      FactoryGirl.create(:student, class_year: 2017)
+      query_object = described_class.new(User.where(class_year: 2016))
+      expect(query_object.call).to eq([2016])
+    end
+    it 'sorts the results' do
+      FactoryGirl.create(:student, class_year: 2017)
+      FactoryGirl.create(:student, class_year: 2016)
+      expect(described_class.call).to eq([2016, 2017])
+    end
+  end
+end

--- a/spec/queries/drawn_suites_for_draw_query_spec.rb
+++ b/spec/queries/drawn_suites_for_draw_query_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawnSuitesForDrawQuery do
+  it 'returns all suites without a draw' do
+    drawn = create_suite_with_draw
+    _undrawn = FactoryGirl.create(:suite)
+    result = described_class.call
+    expect(result.map(&:id)).to eq([drawn.id])
+  end
+
+  it 'restricts the results to the passed query' do
+    suite1 = create_suite_with_draw
+    suite2 = create_suite_with_draw
+    result = described_class.new(Suite.where.not(id: suite1.id)).call
+    expect(result).to eq([suite2])
+  end
+
+  it 'excludes suites belonging to a passed draw' do
+    suite1 = create_suite_with_draw
+    suite2 = create_suite_with_draw
+    suite2.draws.first.suites << suite1
+    result = described_class.call(draw: suite1.draws.first)
+    expect(result.map(&:id)).to eq([suite2.id])
+  end
+
+  def create_suite_with_draw
+    draw = FactoryGirl.create(:draw)
+    suite = FactoryGirl.create(:suite)
+    draw.suites << suite
+    suite
+  end
+end

--- a/spec/queries/suites_by_size_query_spec.rb
+++ b/spec/queries/suites_by_size_query_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuitesBySizeQuery do
+  it 'returns a hash mapping suites to their sizes for the passed relation' do
+    suite = FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+    relation = Suite.where(size: 1)
+    result = described_class.new(relation).call
+    expect(result_numbers(result)).to eq(1 => [suite.number])
+  end
+
+  it 'returns a hash mapping suites to their sizes for all suties by default' do
+    suite1 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    suite2 = FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+    result = described_class.call
+    expect(result_numbers(result)).to \
+      eq(1 => [suite1.number], 2 => [suite2.number])
+  end
+
+  it 'orders suites by number' do
+    suite1 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1, number: 'b')
+    suite2 = FactoryGirl.create(:suite_with_rooms, rooms_count: 1, number: 'a')
+    result = described_class.call
+    expect(result_numbers(result)).to eq(1 => [suite2.number, suite1.number])
+  end
+
+  def result_numbers(result)
+    result.map { |size, suites| [size, suites.map(&:number)] }.to_h
+  end
+end

--- a/spec/queries/undrawn_suites_query_spec.rb
+++ b/spec/queries/undrawn_suites_query_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe UndrawnSuitesQuery do
+  it 'returns all suites without a draw' do
+    undrawn = FactoryGirl.create(:suite)
+    _drawn = create_suite_with_draw
+    result = described_class.call
+    expect(result.map(&:id)).to eq([undrawn.id])
+  end
+
+  it 'restricts the results to the passed query' do
+    suite1, suite2 = FactoryGirl.create_pair(:suite)
+    result = described_class.new(Suite.where.not(id: suite1.id)).call
+    expect(result).to eq([suite2])
+  end
+
+  def create_suite_with_draw
+    draw = FactoryGirl.create(:draw)
+    suite = FactoryGirl.create(:suite)
+    draw.suites << suite
+    suite
+  end
+end


### PR DESCRIPTION
Resolves #181
- Add active boolean attribute to Suite model with scope
- Add :deactivate and :activate model methods to assign attribute value
- Add :deactivate and :activate controller action with routes
- Add SuitesHelper#activation_link to generate either an activation or deactivation link depending on whether or not the suite is active
- Fixed some issues with the SuitePolicy

Blocked on #203 