### PR TITLE
[179] Add suite merging functionality

### DIFF
--- a/app/forms/suite_merger_form.rb
+++ b/app/forms/suite_merger_form.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+#
+# Form / service object for merging two suites together. Ensures suites belong
+# to the same building.
+class SuiteMergerForm
+  include ActiveModel::Model
+
+  attr_reader :other_suite_number, :other_suite
+  attr_writer :number
+
+  validates :suite, presence: true
+  validates :other_suite, presence: { message: 'must be a valid suite' }
+  validates :number, presence: true
+  validates :other_suite_number, presence: true
+  validate :both_suites_different
+  validate :both_suites_in_same_building
+  validate :both_suites_available
+
+  # Allows for calling :submit on the class object
+  def self.submit(**params)
+    new(**params).submit
+  end
+
+  # Initialize a new SuiteMergerForm
+  # @param suite [Suite] the base suite to merge into
+  # @param params [#to_h] the form params from the controller
+  def initialize(suite:, params: nil)
+    @suite = suite
+    process_params(params) if params
+  end
+
+  # Overwrite number accessor to default to suite number
+  #
+  # @return [String] passed number from params or suite number if none passed
+  def number
+    @number ||= suite.try(:number)
+  end
+
+  # Perform the suite merging; deletes both suites, creates a new one, assigns
+  # all of the rooms from the original suites to the new one, and assigns the
+  # new suite to the draw(s) that the original suites belonged to.
+  #
+  # @return [Hash{Symbol=>String,SuiteMergerForm,Nil,Suite,Hash}] a results hash
+  #   for `handle_action`, sets the :object to either the new suite or the
+  #   original suite, :form_object to nil if success or self if failure, and a
+  #   flash message
+  def submit
+    return error(errors.full_messages.join(', ')) unless valid?
+    @new_suite = ActiveRecord::Base.transaction do
+      rooms = find_combined_rooms
+      draws = find_combined_draws
+      destroy_and_create_suites(rooms: rooms, draws: draws)
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => error
+    error(error)
+  end
+
+  private
+
+  attr_accessor :params, :new_suite, :suite
+  attr_writer :other_suite
+
+  def process_params(params)
+    @params = params.to_h.transform_keys(&:to_sym)
+    @other_suite_number = @params[:other_suite_number]
+    @other_suite = find_other_suite
+    @params[:number] = '' unless @params[:number]
+    @number = @params[:number] unless @params[:number].empty?
+  end
+
+  def find_other_suite
+    return nil unless suite
+    Suite.where(building: suite.building)
+         .where('number ILIKE ?', @other_suite_number).includes(:rooms).first
+  end
+
+  def both_suites_different
+    return unless both_suites_present?
+    return if suite.id != other_suite.id
+    errors.add(:base, 'Both suites must be different')
+  end
+
+  def both_suites_in_same_building
+    return unless both_suites_present?
+    return if suite.building == other_suite.building
+    errors.add(:base, 'Both suites must be in the same building')
+  end
+
+  def both_suites_available
+    return unless both_suites_present?
+    %i(suite other_suite).each do |suite|
+      suite_available?(suite)
+    end
+  end
+
+  def suite_available?(suite_symbol)
+    return if send(suite_symbol).available?
+    errors.add(suite_symbol, 'must be available')
+  end
+
+  def both_suites_present?
+    suite.present? && other_suite.present?
+  end
+
+  def find_combined_rooms
+    return unless both_suites_present?
+    suite.rooms + other_suite.rooms
+  end
+
+  def find_combined_draws
+    return unless both_suites_present?
+    (suite.draws + other_suite.draws).uniq
+  end
+
+  def destroy_and_create_suites(rooms: [], draws: [])
+    destroy_old_suites
+    new_suite = Suite.create!(number: number, building: suite.building)
+    rooms.each { |room| room.update!(suite_id: new_suite.id) }
+    draws.each { |draw| draw.suites << new_suite }
+    new_suite.reload
+  end
+
+  def destroy_old_suites
+    suite.destroy!
+    other_suite.destroy!
+  end
+
+  def success
+    {
+      object: new_suite, form_object: nil,
+      msg: { success: 'Suites successfully merged' }
+    }
+  end
+
+  def error(errors)
+    {
+      object: nil, form_object: self,
+      msg: { error: "Suite merger failed: #{errors}" }
+    }
+  end
+end

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -16,7 +16,7 @@ class Suite < ApplicationRecord
                 8 => 'octet' }.freeze
   belongs_to :building
   belongs_to :group
-  has_many :rooms
+  has_many :rooms, dependent: :nullify
   has_many :draws_suites, dependent: :delete_all
   has_many :draws, through: :draws_suites
 
@@ -48,5 +48,12 @@ class Suite < ApplicationRecord
     return number if draws_to_display.empty?
     draws_str = draws_to_display.map(&:name).join(', ')
     "#{number} (#{draws_str})"
+  end
+
+  # Return whether or not a suite is available
+  #
+  # @return [Boolean] whether or not the suite is available
+  def available?
+    group_id.nil?
   end
 end

--- a/app/policies/suite_policy.rb
+++ b/app/policies/suite_policy.rb
@@ -13,6 +13,14 @@ class SuitePolicy < ApplicationPolicy
     true
   end
 
+  def merge?
+    perform_merge?
+  end
+
+  def perform_merge?
+    edit?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/queries/other_suites_in_building_query.rb
+++ b/app/queries/other_suites_in_building_query.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+#
+# Query object to retrieve all other suites in the same building as a passed
+# suite. Can be passed a relation in the initializer to scope the query.
+class OtherSuitesInBuildingQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # initialize an OtherSuitesInBuildingQuery instance
+  #
+  # @param [Suite::ActiveRecord_Relation] base relation to use for the query
+  #   object, defaults to all suites
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the query
+  #
+  # @param suite [Suite] the suite to use as a reference
+  # @return [Suite::ActiveRecord_Relation] the other suites in the same building
+  #   as the passed suite
+  def call(suite:)
+    @relation.where(building: suite.building).where.not(id: suite.id)
+             .available.order(:number)
+  end
+end

--- a/app/views/suites/merge.html.erb
+++ b/app/views/suites/merge.html.erb
@@ -1,0 +1,12 @@
+<h1>Merge suite <%= @suite.number %> and <%= @other_suite.number %></h1>
+<%= simple_form_for @merger_form, url: perform_merge_suite_path(@suite), method: :post do |f| %>
+  <%= f.input :number %>
+  <%= f.input :other_suite_number, as: :hidden  %>
+  <p>The new suite will contain the following rooms:</p>
+  <ul>
+    <% @all_rooms.each do |room| %>
+      <li><%= room.number %> - <%= pluralize(room.beds, 'bed') %></li>
+    <% end %>
+  </ul>
+  <%= f.submit 'Merge' %>
+<% end %>

--- a/app/views/suites/show.html.erb
+++ b/app/views/suites/show.html.erb
@@ -2,9 +2,19 @@
 <h2>Rooms</h2>
 <ul>
   <% @rooms.each do |room| %>
-    <li><%= link_to room.number, room_path(room) %> - <%= pluralize(room.beds,'bed') %></li>
+    <li><%= link_to room.number, room_path(room) %> - <%= pluralize(room.beds, 'bed') %></li>
   <% end %>
 </ul>
 <p><%= link_to 'Add room', new_room_path %></p>
+<% if policy(@suite).merge? %>
+  <div class="suite-merging">
+    <h3>Merge suites</h3>
+    <p>Please enter a suite to merge with this one; <b>it must be in the same building</b>. The two suites will be removed from Vesta and will be replaced with a single suite containing all of their rooms. You will able to set the name/number of the new suite on the following page.</p>
+    <%= simple_form_for @merger_form, url: merge_suite_path(@suite), method: :get do |f| %>
+      <%= f.input :other_suite_number, label: 'Other suite' %>
+      <%= f.submit 'Merge' %>
+    <% end %>
+  </div>
+<% end %>
 <p><%= link_to 'Delete', suite_path(@suite), method: :delete %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   root to: 'application#home'
   resources :buildings
   resources :suites
+  get 'suites/:id/merge', to: 'suites#merge', as: 'merge_suite'
+  post 'suites/:id/merge', to: 'suites#perform_merge', as: 'perform_merge_suite'
   resources :rooms
   get 'users/build', to: 'users#build', as: 'build_user'
   resources :users

--- a/spec/features/suites/suite_merging_spec.rb
+++ b/spec/features/suites/suite_merging_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Suite merging' do
+  let(:suite) { FactoryGirl.create(:suite_with_rooms) }
+  let!(:other_suite) do
+    FactoryGirl.create(:suite_with_rooms, building: suite.building)
+  end
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be performed' do
+    initiate_suite_merger
+    fill_in 'suite_merger_form_number', with: 'New Suite'
+    click_on 'Merge'
+    msg = 'Suites successfully merged'
+    expect(page).to have_css('.flash-success', text: msg)
+  end
+
+  it 'defaults to the number of the first suite' do
+    initiate_suite_merger
+    expect(page).to \
+      have_css("input#suite_merger_form_number[value=#{suite.number}]")
+  end
+
+  def initiate_suite_merger
+    visit suite_path(suite)
+    fill_in 'suite_merger_form_other_suite_number', with: other_suite.number
+    click_on 'Merge'
+  end
+end

--- a/spec/forms/suite_merger_form_spec.rb
+++ b/spec/forms/suite_merger_form_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuiteMergerForm, type: :model do
+  describe '.submit' do
+    xit 'calls #submit on a new instance of SuiteMergerForm'
+  end
+
+  describe 'validations' do
+    it 'requires a suite' do
+      params = mock_params(other_suite_number: '1234', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(instance_spy('Suite'))
+      object = described_class.new(suite: nil, params: params)
+      expect(object).not_to be_valid
+    end
+    it 'requires a number' do
+      suite = FactoryGirl.build(:suite, number: nil)
+      params = mock_params(other_suite_number: '1234', number: nil)
+      allow(Suite).to receive(:find_by).and_return(instance_spy('Suite'))
+      object = described_class.new(suite: suite, params: params)
+      expect(object).not_to be_valid
+    end
+    it 'requires a valid other_suite' do
+      suite = FactoryGirl.build(:suite)
+      params = mock_params(other_suite_number: '1234', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(nil)
+      object = described_class.new(suite: suite, params: params)
+      expect(object).not_to be_valid
+    end
+    it 'validates that both suites are different' do
+      suite = FactoryGirl.build(:suite, id: 1234)
+      params = mock_params(other_suite_number: '1234', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(suite)
+      object = described_class.new(suite: suite, params: params)
+      expect(object).not_to be_valid
+    end
+    it 'validates that both suites are in the same building' do
+      suite, other_suite = FactoryGirl.build_pair(:suite)
+      params = mock_params(other_suite_number: '1234', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(other_suite)
+      object = described_class.new(suite: suite, params: params)
+      expect(object).not_to be_valid
+    end
+    # rubocop:disable RSpec/ExampleLength
+    it 'validates that the suite is available' do
+      suite = FactoryGirl.build(:suite, group_id: 123, id: 123)
+      other_suite = FactoryGirl.build(:suite, building: suite.building, id: 124)
+      params = mock_params(other_suite_number: '124', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(other_suite)
+      object = described_class.new(suite: suite, params: params)
+      expect(object).not_to be_valid
+    end
+    it 'validates that the other_suite is available' do
+      suite = FactoryGirl.build(:suite, group_id: 123, id: 123)
+      other_suite = FactoryGirl.build(:suite, building: suite.building, id: 124)
+      params = mock_params(other_suite_number: '124', number: 'foo')
+      allow(Suite).to receive(:find_by).and_return(suite)
+      object = described_class.new(suite: other_suite, params: params)
+      expect(object).not_to be_valid
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe '#submit' do
+    let(:suite) { FactoryGirl.create(:suite_with_rooms) }
+    context 'success' do
+      let(:other_suite) do
+        FactoryGirl.create(:suite_with_rooms, building: suite.building)
+      end
+      let(:params) do
+        other = FactoryGirl.create(:suite_with_rooms, building: suite.building)
+        mock_params(other_suite_number: other.number, number: 'foo')
+      end
+      it 'creates a new suite of the combined size' do
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:object].size).to eq(suite.size + other_suite.size)
+      end
+      it 'creates a new suite with the defined number' do
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:object].number).to eq('foo')
+      end
+      it 'creates a new suite with the correct building' do
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:object].building).to eq(suite.building)
+      end
+      it 'creates a new suite with the correct draw' do
+        draw = FactoryGirl.create(:draw)
+        draw.suites << suite
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:object].draws.map(&:id)).to include(draw.id)
+      end
+      it 'returns nil for :form_object' do
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:form_object]).to be_nil
+      end
+      it 'sets a success message' do
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:msg]).to have_key(:success)
+      end
+    end
+
+    context 'failures' do
+      it 'returns nil as the object' do
+        params = mock_params(other_suite_number: nil)
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:object]).to be_nil
+      end
+      it 'returns the form object' do
+        params = mock_params(other_suite_number: nil)
+        object = described_class.new(suite: suite, params: params)
+        expect(object.submit[:form_object]).to eq(object)
+      end
+      it 'sets an error message' do
+        params = mock_params(other_suite_number: nil)
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+      it 'fails if any update fails' do
+        other_suite = FactoryGirl.create(:suite, building: suite.building)
+        params = mock_params(other_suite_number: other_suite.number)
+        allow(Suite).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+        result = described_class.submit(suite: suite, params: params)
+        expect(result[:msg]).to have_key(:error)
+      end
+    end
+  end
+
+  def mock_params(other_suite_number: nil, number: nil)
+    hash = { other_suite_number: other_suite_number, number: number }
+    instance_spy('ActionController::Parameters', to_h: hash)
+  end
+end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Room, type: :model do
     it { is_expected.to validate_presence_of(:beds) }
     it { is_expected.not_to allow_value(-1).for(:beds) }
     it { is_expected.to belong_to(:suite) }
+    it { is_expected.to validate_presence_of(:suite) }
     describe 'number uniqueness' do
       it 'allows duplicates that belong to separate suites' do
         number = 'A'
@@ -63,6 +64,18 @@ RSpec.describe Room, type: :model do
       room = FactoryGirl.create(:room, beds: 1, suite: suite)
       room.update_attributes(beds: 2)
       expect(suite).to have_received(:increment!).with(:size, 1).twice
+    end
+    it 'updates the new suite when switching' do
+      old_suite, new_suite = FactoryGirl.create_pair(:suite)
+      room = FactoryGirl.create(:room, beds: 1, suite: old_suite)
+      expect { room.update(suite_id: new_suite.id) }.to \
+        change { old_suite.reload.size }.by(-1)
+    end
+    it 'updates the new suite when switching' do
+      old_suite, new_suite = FactoryGirl.create_pair(:suite)
+      room = FactoryGirl.create(:room, beds: 1, suite: old_suite)
+      expect { room.update(suite_id: new_suite.id) }.to \
+        change { new_suite.reload.size }.by(1)
     end
   end
 end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -100,4 +100,15 @@ RSpec.describe Suite, type: :model do
       expect(draw.suites.first.number_with_draws(draw2)).to eq(expected)
     end
   end
+
+  describe '#available?' do
+    it 'returns true if the suite has no group assigned' do
+      suite = FactoryGirl.build(:suite, group_id: nil)
+      expect(suite).to be_available
+    end
+    it 'returns false if the suite has a group assigned' do
+      suite = FactoryGirl.build(:suite, group_id: 123)
+      expect(suite).not_to be_available
+    end
+  end
 end

--- a/spec/policies/suite_policy_spec.rb
+++ b/spec/policies/suite_policy_spec.rb
@@ -13,14 +13,15 @@ RSpec.describe SuitePolicy do
     permissions :index? do
       it { is_expected.to permit(user, Suite) }
     end
-    permissions :create?, :destroy?, :edit?, :update? do
+    permissions :create?, :destroy?, :edit?, :update?, :merge?,
+                :perform_merge? do
       it { is_expected.not_to permit(user, suite) }
     end
   end
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show?, :edit?, :update? do
+    permissions :show?, :edit?, :update?, :merge?, :perform_merge? do
       it { is_expected.to permit(user, suite) }
     end
     permissions :index? do
@@ -33,7 +34,8 @@ RSpec.describe SuitePolicy do
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :show?, :edit?, :update?, :create?, :destroy? do
+    permissions :show?, :edit?, :update?, :create?, :destroy?, :merge?,
+                :perform_merge? do
       it { is_expected.to permit(user, suite) }
     end
     permissions :index? do

--- a/spec/queries/other_suites_in_building_query_spec.rb
+++ b/spec/queries/other_suites_in_building_query_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe OtherSuitesInBuildingQuery do
+  it 'returns all other suites in the building of the passed suite' do
+    suite = FactoryGirl.create(:suite)
+    result = FactoryGirl.create(:suite, building: suite.building)
+    FactoryGirl.create(:suite)
+    expect(described_class.call(suite: suite).map(&:id)).to eq([result.id])
+  end
+  it 'can be scoped in the initializer' do
+    suite = FactoryGirl.create(:suite)
+    result, other = FactoryGirl.create_pair(:suite, building: suite.building)
+    object = described_class.new(Suite.where.not(id: other.id))
+    expect(object.call(suite: suite).map(&:id)).to eq([result.id])
+  end
+  it 'ignores unavailable suites' do
+    suite = FactoryGirl.create(:suite)
+    _other = FactoryGirl.create(:suite, building: suite.building, group_id: 123)
+    expect(described_class.call(suite: suite)).to eq([])
+  end
+end


### PR DESCRIPTION
Resolves #179
- Add SuiteMergerForm form / service object
- Add OtherSuitesInBuildingQuery query object
- Add routes / view / policies for suite merger
- Update suite size counter cache callbacks in Room to handle switching the suite