### PR TITLE
[204] Add locked suite sizes to draws

### DIFF
--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -20,7 +20,11 @@ class Draw < ApplicationRecord
   enum status: %w(draft pre_lottery)
 
   def suite_sizes
-    suites.map(&:size).uniq
+    SuiteSizesQuery.new(suites).call
+  end
+
+  def open_suite_sizes
+    suite_sizes - locked_sizes
   end
 
   # Query method to see if a draw has at least one student.

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -82,7 +82,7 @@ class Group < ApplicationRecord
     # often then we can extract special group functionality into a subclass that
     # still talks to the same table in the db to keep things clean.
     if draw.present?
-      return if draw.suite_sizes.include? size
+      return if draw.open_suite_sizes.include? size
       errors.add :size, 'must be a suite size included in the draw'
     else
       return if SuiteSizesQuery.call.include? size

--- a/db/migrate/20170221200355_add_locked_sizes_to_draws.rb
+++ b/db/migrate/20170221200355_add_locked_sizes_to_draws.rb
@@ -1,0 +1,5 @@
+class AddLockedSizesToDraws < ActiveRecord::Migration[5.0]
+  def change
+    add_column :draws, :locked_sizes, :integer, array: true, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208040633) do
+ActiveRecord::Schema.define(version: 20170221200355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,10 +38,11 @@ ActiveRecord::Schema.define(version: 20170208040633) do
 
   create_table "draws", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "status",          default: 0, null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.integer  "status",          default: 0,  null: false
     t.date     "intent_deadline"
+    t.integer  "locked_sizes",    default: [], null: false, array: true
   end
 
   create_table "draws_suites", id: false, force: :cascade do |t|

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Draw, type: :model do
 
   describe '#suite_sizes' do
     it 'returns an array of all the suite sizes in the draw' do
-      suites = Array.new(3) { |size| instance_spy('Suite', size: size + 1) }
       draw = FactoryGirl.build_stubbed(:draw)
-      allow(draw).to receive(:suites).and_return(suites)
-      expect(draw.suite_sizes).to match_array([1, 2, 3])
+      instance_spy('SuiteSizesQuery', call: [1, 2]).tap do |q|
+        allow(SuiteSizesQuery).to receive(:new).with(draw.suites).and_return(q)
+      end
+      expect(draw.suite_sizes).to match_array([1, 2])
     end
   end
 
@@ -57,6 +58,15 @@ RSpec.describe Draw, type: :model do
       allow(draw).to receive(:bed_count).and_return(1)
       allow(draw).to receive(:student_count).and_return(2)
       expect(draw.enough_beds?).to be_falsey
+    end
+  end
+
+  describe '#open_suite_sizes' do
+    it 'returns suite sizes in the draw minus locked sizes' do
+      draw = FactoryGirl.build_stubbed(:draw, locked_sizes: [1])
+      all_sizes = [1, 2]
+      allow(draw).to receive(:suite_sizes).and_return(all_sizes)
+      expect(draw.open_suite_sizes).to eq([2])
     end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Group, type: :model do
     context 'for regular groups' do
       it 'must be available in the draw' do
         group = FactoryGirl.build(:group)
-        allow(group.draw).to receive(:suite_sizes).and_return([1])
+        allow(group.draw).to receive(:open_suite_sizes).and_return([1])
         group.size = 2
         expect(group.valid?).to be_falsey
       end


### PR DESCRIPTION
Resolves #204
  - Changes group size validation to check against non-locked sizes
  - Draw#suite_sizes now uses SuiteSizesQuery object