### PR TITLE
[219] Fix Draw#bed_count to include suite availability

### DIFF
--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -48,7 +48,10 @@ class Draw < ApplicationRecord
     @student_count ||= students.count
   end
 
+  # Calculate the number of beds that exist across all available suites
+  #
+  # @return [Integer] the number of beds in all available suites
   def bed_count
-    @bed_count ||= suites.sum(:size)
+    @bed_count ||= suites.available.sum(:size)
   end
 end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -69,4 +69,12 @@ RSpec.describe Draw, type: :model do
       expect(draw.open_suite_sizes).to eq([2])
     end
   end
+
+  describe '#bed_count' do
+    it 'returns the number of beds across all available suites' do
+      draw = FactoryGirl.create(:draw_with_members, suites_count: 2)
+      draw.suites.last.update(group_id: 123)
+      expect(draw.send(:bed_count)).to eq(draw.suites.first.size)
+    end
+  end
 end


### PR DESCRIPTION
Resolves #219 

Since `bed_count` is a private method it wasn't currently tested, and we were stubbing it out to test `enough_beds?`, there were no tests for this. That smells a bit to me, let me know if you want to either make `bed_count` public or test it somehow;