### PR TITLE
[193] Allow admins to add transfer students to groups

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -44,8 +44,8 @@ class DrawlessGroupsController < ApplicationController
   end
 
   def drawless_group_params
-    params.require(:group).permit(:size, :leader_id, :suite, member_ids: [],
-                                                             remove_ids: [])
+    params.require(:group).permit(:size, :leader_id, :suite, :transfers,
+                                  member_ids: [], remove_ids: [])
   end
 
   def set_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -94,9 +94,9 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:size, :leader_id, member_ids: [],
-                                                     remove_ids: [],
-                                                     invitations: [])
+    params.require(:group).permit(:size, :leader_id, :transfers,
+                                  member_ids: [], remove_ids: [],
+                                  invitations: [])
   end
 
   def set_group

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -17,6 +17,10 @@ class GroupPolicy < ApplicationPolicy
     record.leader == user || user.admin?
   end
 
+  def advanced_edit?
+    user.admin?
+  end
+
   def destroy?
     edit?
   end

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -1,9 +1,10 @@
 <div class="form-inputs">
   <%= f.input :size, collection: @suite_sizes %>
-  <% if current_user.admin? %>
+  <% if policy(@group).advanced_edit? %>
     <%= f.association :leader, label_method: :full_name, collection: @leader_students %>
     <%= f.input :remove_ids, label: 'Users to remove', collection: @group.removable_members, label_method: :full_name, as: :check_boxes unless @group.removable_members.empty? %>
     <%= f.input :member_ids, label: 'Users to add', label_method: :full_name, as: :check_boxes, collection: @students %>
+    <%= f.input :transfers, label: '# transfer students' %>
   <% end %>
 </div>
 

--- a/app/views/groups/_group_details.html.erb
+++ b/app/views/groups/_group_details.html.erb
@@ -7,3 +7,6 @@
     <li class="group-member"><%= m.full_name %></li>
   <% end %>
 </ul>
+<% unless @group.transfers.zero? %>
+  <h2 class="transfers">Transfers: <%= @group.transfers %></h2>
+<% end %>

--- a/db/migrate/20170227011341_add_transfers_to_groups.rb
+++ b/db/migrate/20170227011341_add_transfers_to_groups.rb
@@ -1,0 +1,5 @@
+class AddTransfersToGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :groups, :transfers, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170221200355) do
+ActiveRecord::Schema.define(version: 20170227011341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 20170221200355) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.integer  "memberships_count", default: 0, null: false
+    t.integer  "transfers",         default: 0, null: false
     t.index ["draw_id"], name: "index_groups_on_draw_id", using: :btree
     t.index ["leader_id"], name: "index_groups_on_leader_id", using: :btree
   end

--- a/spec/features/groups/drawless_group_editing_spec.rb
+++ b/spec/features/groups/drawless_group_editing_spec.rb
@@ -35,6 +35,14 @@ RSpec.feature 'Special group editing' do
   end
   # rubocop:enable RSpec/ExampleLength
 
+  it 'can modify the number of transfer students' do
+    group = FactoryGirl.create(:drawless_group, size: 2)
+    visit edit_group_path(group)
+    fill_in 'group_transfers', with: '1'
+    click_on 'Save'
+    expect(page).to have_css('.transfers', text: 'Transfers: 1')
+  end
+
   def update_group_size(new_size)
     select new_size, from: 'group_size'
     click_on 'Save'

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Group, type: :model do
     it { is_expected.to have_many(:full_memberships) }
     it { is_expected.to have_many(:members).through(:full_memberships) }
     it { is_expected.not_to allow_value(-1).for(:memberships_count) }
+    it { is_expected.to validate_presence_of(:transfers) }
+    it { is_expected.not_to allow_value(-1).for(:transfers) }
   end
 
   describe 'size validations' do
@@ -49,6 +51,10 @@ RSpec.describe Group, type: :model do
       group.save
       expect(group.persisted?).to be_falsey
     end
+    it 'takes transfers into account' do
+      group = FactoryGirl.create(:open_group, size: 2, transfers: 1)
+      expect(group).to be_full
+    end
   end
 
   describe 'status validations' do
@@ -67,6 +73,11 @@ RSpec.describe Group, type: :model do
       group = FactoryGirl.build(:open_group)
       group.status = 'full'
       expect(group.valid?).to be_falsey
+    end
+    it 'takes transfers into account' do
+      group = FactoryGirl.create(:open_group, size: 2, transfers: 1)
+      group.status = 'open'
+      expect(group).not_to be_valid
     end
     it 'cannot be open when members match the size' do
       group = FactoryGirl.create(:full_group, size: 2)

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe GroupPolicy do
       before { allow(group).to receive(:full?).and_return(true) }
       it { is_expected.to permit(user, group) }
     end
-    permissions :lock? do
+    permissions :lock?, :advanced_edit? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -240,7 +240,7 @@ RSpec.describe GroupPolicy do
         it { is_expected.not_to permit(user, other_group) }
       end
     end
-    permissions :lock? do
+    permissions :lock?, :advanced_edit? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -260,20 +260,14 @@ RSpec.describe GroupPolicy do
       it { is_expected.to permit(user, [group]) }
     end
     permissions :show?, :edit?, :update?, :destroy?, :accept_request?,
-                :invite_to_join? do
+                :invite_to_join?, :lock?, :advanced_edit? do
       it { is_expected.to permit(user, group) }
     end
-    permissions :request_to_join? do
+    permissions :request_to_join?, :finalize_membership? do
       it { is_expected.not_to permit(user, group) }
     end
     permissions :finalize? do
       before { allow(group).to receive(:full?).and_return(true) }
-      it { is_expected.to permit(user, group) }
-    end
-    permissions :finalize_membership? do
-      it { is_expected.not_to permit(user, group) }
-    end
-    permissions :lock? do
       it { is_expected.to permit(user, group) }
     end
   end


### PR DESCRIPTION
Resolves #193
- Add transfers attribute to groups
- Add advanced_edit? policy permission for groups
- Replace `memberships_count` references in group validations with `members_count`, which takes transfers into account