### PR TITLE
[242] Improve Groups#show view

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -6,7 +6,10 @@ class GroupsController < ApplicationController
   prepend_before_action :set_draw
   before_action :set_form_data, only: %i(new edit)
 
-  def show; end
+  def show
+    @same_size_groups_count = @draw.groups.where(size: @group.size).count
+    @compatible_suites = @draw.suites.available.where(size: @group.size)
+  end
 
   def new; end
 

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+#
+# Helper methods for the Groups views
+module GroupsHelper
+  delegate :size_str, to: Suite
+
+  # Generate the user listing for a group member; includes membership lock
+  # status
+  #
+  # @param member [User] the user
+  # @param group [Group] the user's group
+  # @return [String] the user listing
+  def member_str(member, group)
+    membership = group.memberships.find_by(user_id: member.id)
+    locked_str = membership.locked? ? ' (locked)' : ''
+    member.full_name + locked_str
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,6 +2,8 @@
 #
 # Helper methods for the Users views
 module UsersHelper
+  delegate :size_str, to: Suite
+
   # Generate a form field for a profile attribute. Should be disabled if the
   # attribute is defined on the passed user object, and should include a hidden
   # field if disabled.

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -56,4 +56,28 @@ class Suite < ApplicationRecord
   def available?
     group_id.nil?
   end
+
+  # Return all single-bed rooms in the suite
+  #
+  # @return [Room::ActiveRecord_AssociationRelation] relation for all of the
+  #   rooms with 1 bed
+  def singles
+    rooms.where(beds: 1)
+  end
+
+  # Return all double-bed rooms in the suite
+  #
+  # @return [Room::ActiveRecord_AssociationRelation] relation for all of the
+  #   rooms with 2 bed
+  def doubles
+    rooms.where(beds: 2)
+  end
+
+  # Return all common rooms in the suite
+  #
+  # @return [Room::ActiveRecord_AssociationRelation] relation for all of the
+  #   common rooms
+  def common_rooms
+    rooms.where(beds: 0)
+  end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -67,6 +67,10 @@ class GroupPolicy < ApplicationPolicy
     record.locked? && (user.admin? || user.rep?)
   end
 
+  def view_pending_members?
+    edit? || user.rep?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/views/drawless_groups/show.html.erb
+++ b/app/views/drawless_groups/show.html.erb
@@ -13,7 +13,8 @@
     <% end %>
   <% end %>
 <% end %>
-<% if policy(@group).lock? %>
-  <%= link_to 'Lock Group', lock_group_path(@group), method: :put %>
-<% end %>
-<%= link_to 'Delete', group_path(@group), method: :delete %>
+<p>
+  <%= link_to 'Edit', edit_group_path(@group), class: 'button secondary' if policy(@group).edit? %>
+  <%= link_to 'Lock Group', lock_group_path(@group), method: :put, class: 'button alert' if policy(@group).lock? %>
+  <%= link_to('Disband', group_path(@group), method: :delete, class: 'button alert') if policy(@group).destroy? %>
+</p>

--- a/app/views/groups/_group_details.html.erb
+++ b/app/views/groups/_group_details.html.erb
@@ -1,12 +1,12 @@
-<h1 class="group-name"><%= @group.name %></h1>
-<h2 class="group-size">Size: <%= @group.size %></h2>
-<h2 class="group-status">Status: <%= @group.status %></h2>
-<h2 class="group-members">Members:</h2>
+<h2 class="group-name"><%= @group.name %></h2>
+<h3 class="group-size">Size: <%= @group.size %></h3>
+<h3 class="group-status">Status: <%= @group.status %></h3>
+<h3 class="group-members">Members:</h3>
 <ul>
   <% @group.members.each do |m| %>
-    <li class="group-member"><%= m.full_name %></li>
+    <li class="group-member"><%= member_str(m, @group) %></li>
   <% end %>
 </ul>
 <% unless @group.transfers.zero? %>
-  <h2 class="transfers">Transfers: <%= @group.transfers %></h2>
+  <h3 class="transfers">Transfers: <%= @group.transfers %></h3>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,26 +1,63 @@
 <%= render 'group_details' %>
-<% if policy(@group).accept_request? %>
-  <h2>Membership Requests</h2>
-  <% @group.requests.each do |u| %>
-    <%= link_to "Accept #{u.full_name}", draw_group_accept_request_path(@draw, @group, params: { 'user_id' => u.id }), method: :put %>
+<% if policy(@group).view_pending_members? %>
+  <% unless @group.requests.empty? %>
+    <h3 class="group-requests">Requests:</h3>
+    <ul>
+      <% @group.requests.each do |r| %>
+        <li class="group-request">
+          <%= r.full_name %>
+          <% if policy(@group).accept_request? %>
+            (<%= link_to 'accept', draw_group_accept_request_path(@draw, @group, params: { 'user_id' => r.id }), method: :put %>)
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% unless @group.invitations.empty? %>
+    <h3 class="group-invitations">Invitations:</h3>
+    <ul>
+      <% @group.invitations.each do |i| %>
+        <li class="group-invitation"><%= i.full_name %></li>
+      <% end %>
+    </ul>
   <% end %>
 <% end %>
-<% if policy(@group).request_to_join? %>
-  <%= link_to 'Request To Join', draw_group_request_path(@draw, @group), method: :post %>
+<div style="border-top: 1px solid #DDDDDD;">
+  <br />
+  <%= link_to 'Edit', edit_draw_group_path(@draw, @group), class: 'button secondary' if policy(@group).edit? %>
+  <%= link_to 'Request To Join', draw_group_request_path(@draw, @group), method: :post, class: 'button secondary' if policy(@group).request_to_join? %>
+  <%= link_to 'Invite Members', draw_group_invite_path(@draw, @group), class: 'button secondary' if policy(@group).invite_to_join? %>
+  <%= link_to 'Accept Invitation', draw_group_accept_invitation_path(@draw, @group), method: :put, class: 'button' if policy(@group).accept_invitation? %>
+  <%= link_to 'Lock Group', draw_group_lock_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).lock? %>
+  <%= link_to 'Finalize Group', draw_group_finalize_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize? %>
+  <%= link_to 'Finalize Membership', draw_group_finalize_membership_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize_membership? %>
+  <%= link_to('Disband', draw_group_path(@draw, @group), method: :delete, class: 'button alert') if policy(@group).destroy? %>
+</div>
+<%= link_to 'Return to draw', draw_path(@draw) %>
+
+<% content_for :sidebar do %>
+  <h3><%= @same_size_groups_count %> <%= 'group'.pluralize(@same_size_groups_count) %> of size <%= @group.size %></h3>
+  <h3><%= @compatible_suites.count %> available <%= size_str(@group.size).capitalize.pluralize(@compatible_suites.count) %></h3>
+  <% unless @compatible_suites.count.zero? %>
+    <table>
+      <thead>
+        <tr>
+          <td>Suite #</td>
+          <td>S</td>
+          <td>D</td>
+          <td>C</td>
+        </tr>
+      </thead>
+      <tbody>
+        <% @compatible_suites.each do |suite| %>
+          <tr>
+            <td><%= link_to suite.number, suite_path(suite) %></td>
+            <td><%= suite.singles.count %></td>
+            <td><%= suite.doubles.count %></td>
+            <td><%= suite.common_rooms.count %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 <% end %>
-<% if policy(@group).invite_to_join? %>
-  <%= link_to 'Invite Members', draw_group_invite_path(@draw, @group) %>
-<% end %>
-<% if policy(@group).accept_invitation? %>
-  <%= link_to 'Accept Invitation', draw_group_accept_invitation_path(@draw, @group), method: :put %>
-<% end %>
-<% if policy(@group).lock? %>
-  <%= link_to 'Lock Group', draw_group_lock_path(@draw, @group), method: :put %>
-<% end %>
-<% if policy(@group).finalize? %>
-  <%= link_to 'Finalize Group', draw_group_finalize_path(@draw, @group), method: :put %>
-<% end %>
-<% if policy(@group).finalize_membership? %>
-  <%= link_to 'Finalize Membership', draw_group_finalize_membership_path(@draw, @group), method: :put %>
-<% end %>
-<%= link_to('Delete', draw_group_path(@draw, @group), method: :delete) if policy(@group).destroy? %>

--- a/spec/features/groups/drawless_group_deletion_spec.rb
+++ b/spec/features/groups/drawless_group_deletion_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Special group deletion' do
   it 'succeeds' do
     msg = "Group #{group.name} deleted."
     visit group_path(group)
-    click_on 'Delete'
+    click_on 'Disband'
     expect(page).to have_content(msg)
   end
 end

--- a/spec/features/groups/group_deletion_spec.rb
+++ b/spec/features/groups/group_deletion_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Group deletion' do
   it 'succeeds' do
     msg = "Group #{group.name} deleted."
     visit draw_group_path(group.draw, group)
-    click_on 'Delete'
+    click_on 'Disband'
     expect(page).to have_content(msg)
   end
 end

--- a/spec/features/groups/request_to_join_spec.rb
+++ b/spec/features/groups/request_to_join_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'Students Joining Groups' do
       Membership.create(group: group, user: user, status: 'requested')
       log_in group.leader
       visit draw_group_path(group.draw, group)
-      click_on "Accept #{user.full_name}"
+      click_on 'accept'
       expect(page).to have_content("#{user.full_name} joined group")
     end
   end

--- a/spec/helpers/groups_helper_spec.rb
+++ b/spec/helpers/groups_helper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GroupsHelper, type: :helper do
+  context '#member_str' do
+    let(:membership) { instance_spy('membership') }
+    let(:member) { instance_spy('user', id: 123, full_name: 'First Last') }
+    let(:group) { mock_group(member, membership) }
+
+    it 'returns the full name with an unlocked membership' do
+      allow(membership).to receive(:locked?).and_return(false)
+      expect(helper.member_str(member, group)).to eq(member.full_name)
+    end
+
+    it 'returns the full name and notes a locked membership' do
+      allow(membership).to receive(:locked?).and_return(true)
+      expect(helper.member_str(member, group)).to \
+        eq(member.full_name + ' (locked)')
+    end
+
+    def mock_group(member, membership)
+      instance_spy('group').tap do |group|
+        allow(group).to receive(:memberships).and_return(group)
+        allow(group).to receive(:find_by).with(user_id: member.id)
+          .and_return(membership)
+      end
+    end
+  end
+end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -111,4 +111,32 @@ RSpec.describe Suite, type: :model do
       expect(suite).not_to be_available
     end
   end
+
+  describe 'room helpers' do
+    let(:suite) { FactoryGirl.create(:suite) }
+    let(:single) { FactoryGirl.create(:single) }
+    let(:double) { FactoryGirl.create(:double) }
+    let(:common) { FactoryGirl.create(:room, beds: 0) }
+    before do
+      suite.rooms << single
+      suite.rooms << double
+      suite.rooms << common
+    end
+
+    describe '#singles' do
+      it 'returns all of the single rooms belonging to the suite' do
+        expect(suite.singles).to eq([single])
+      end
+    end
+    describe '#doubles' do
+      it 'returns all of the double rooms belonging to the suite' do
+        expect(suite.doubles).to eq([double])
+      end
+    end
+    describe '#common_rooms' do
+      it 'returns all of the common rooms belonging to the suite' do
+        expect(suite.common_rooms).to eq([common])
+      end
+    end
+  end
 end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe GroupPolicy do
       it { is_expected.to permit(user, other_group) }
     end
     permissions :destroy?, :edit?, :update?, :accept_request?,
-                :invite_to_join?, :edit_invitations? do
+                :invite_to_join?, :edit_invitations?, :view_pending_members? do
       context 'not finalizing or locked' do
         before do
           allow(group).to receive(:finalizing?).and_return(false)
@@ -174,7 +174,7 @@ RSpec.describe GroupPolicy do
     permissions :index? do
       it { is_expected.to permit(user, [group, other_group]) }
     end
-    permissions :show? do
+    permissions :show?, :view_pending_members? do
       it { is_expected.to permit(user, group) }
       it { is_expected.to permit(user, other_group) }
     end
@@ -314,7 +314,7 @@ RSpec.describe GroupPolicy do
       it { is_expected.to permit(user, [group]) }
     end
     permissions :show?, :edit?, :update?, :destroy?, :accept_request?,
-                :invite_to_join?, :advanced_edit? do
+                :invite_to_join?, :advanced_edit?, :view_pending_members? do
       it { is_expected.to permit(user, group) }
     end
     permissions :lock? do


### PR DESCRIPTION
Resolves #242
- Add size_str helper to GroupsHelper (delegated to Suite)
- Add GroupsHelper#member_str
- Add room helpers to Suites (#singles, #doubles, #common_rooms)
- Add request / invitation information to the group page, only accessible to admins, reps, and the group leader
- Change most action links to buttons
- Add compatible suites to sidebar