### PR TITLE
[183] Add the ability to start the lottery phase of a draw

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -3,7 +3,7 @@
 # Controller for Draws
 class DrawsController < ApplicationController # rubocop:disable ClassLength
   prepend_before_action :set_draw, except: %i(index new create)
-  before_action :calculate_metrics, only: [:show, :activate]
+  before_action :calculate_metrics, only: %i(show activate start_lottery)
 
   def show; end
 
@@ -114,6 +114,11 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
       result[:path] = draw_student_summary_path(@draw)
     end
     result
+  end
+
+  def start_lottery
+    result = DrawLotteryStarter.start(draw: @draw)
+    handle_action(action: 'show', **result)
   end
 
   def lottery; end

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -80,4 +80,12 @@ class Suite < ApplicationRecord
   def common_rooms
     rooms.where(beds: 0)
   end
+
+  # Return whether or not a suite can be selected in a new draw (e.g. it is not
+  # currently in any draw that is in the lottery or suite_selection phase)
+  #
+  # @return [Boolean] whether or not the suite is selectable
+  def selectable?
+    draws.all? { |draw| !(draw.lottery? || draw.suite_selection?) }
+  end
 end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -54,6 +54,10 @@ class DrawPolicy < ApplicationPolicy
     oversub_report?
   end
 
+  def start_lottery?
+    edit? && record.pre_lottery?
+  end
+
   def lottery?
     record.lottery? && (user.admin? || user.rep?)
   end

--- a/app/services/draw_lottery_starter.rb
+++ b/app/services/draw_lottery_starter.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+#
+# Service object to handle the starting of the lottery phase for a draw. Checks
+# to make sure that the draw has the correct status and has enough beds for
+# students, as well as no ungrouped students, and updates the status.
+class DrawLotteryStarter
+  include ActiveModel::Model
+
+  attr_reader :draw
+
+  # validates :draw, presence: :true
+  validate :draw_in_pre_lottery_phase
+  validate :at_least_one_group
+  validate :no_ungrouped_students
+  validate :enough_beds
+  validate :no_contested_suites
+  validate :all_groups_locked
+
+  # Class method to permit calling :start on the class without instantiating the
+  # service object directly
+  def self.start(**params)
+    new(**params).start
+  end
+
+  # Initialize a new DrawLotteryStarter
+  #
+  # @param draw [Draw] the draw in question
+  def initialize(draw:)
+    @draw = draw
+  end
+
+  # Start the lottery phase of a Draw
+  #
+  # @return [Hash{Symbol=>ApplicationRecord,Hash}] A results hash with the
+  #   message to set in the flash and either `nil` or the modified object.
+  def start
+    return error unless valid?
+    return success if draw.update(status: 'lottery')
+    errors.add(:base, 'Draw update failed')
+    error
+  end
+
+  private
+
+  attr_writer :draw
+
+  def draw_in_pre_lottery_phase
+    return if draw.nil? || draw.pre_lottery?
+    errors.add(:draw, 'must be in the pre-lottery phase')
+  end
+
+  def at_least_one_group
+    return if draw.nil? || draw.groups?
+    errors.add(:draw, 'must have at least one group')
+  end
+
+  def no_ungrouped_students
+    return unless draw.present? && draw.ungrouped_students?
+    errors.add(:draw, 'cannot have any students not in groups')
+  end
+
+  def enough_beds
+    return if draw.nil? || draw.enough_beds?
+    errors.add(:draw, 'must have at least one bed per student in all suites')
+  end
+
+  def no_contested_suites
+    return if draw.nil? || draw.no_contested_suites?
+    errors.add(:draw,
+               'cannot contain any suites in other draws that are in the '\
+               'lottery or suite selection phase')
+  end
+
+  def all_groups_locked
+    return if draw.nil? || draw.all_groups_locked?
+    errors.add(:draw, 'cannot have any unlocked groups')
+  end
+
+  def success
+    { object: draw, msg: { success: 'You can now assign lottery numbers' } }
+  end
+
+  def error
+    msg = "There was a problem proceeding to the lottery phase:\n#{error_msgs}"
+    { object: nil, msg: { error: msg } }
+  end
+
+  def error_msgs
+    errors.full_messages.join(', ')
+  end
+end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -31,21 +31,26 @@
     <%= render 'group_report', sizes: @suite_sizes, groups: @groups_by_size, actions_partial: 'groups/actions' %>
   </div>
 <% end %>
-<% if policy(@draw).student_summary? %>
-  <p><%= link_to 'View students', draw_student_summary_path(@draw) %></p>
-<% end %>
-<% if policy(@draw).suite_summary? %>
-  <p><%= link_to 'View suites', draw_suite_summary_path(@draw) %></p>
-<% end %>
-<% if policy(@draw).lottery? %>
-  <p><%= link_to 'Assign lottery numbers', draw_lottery_path(@draw) %></p>
-<% end %>
-<% if policy(@draw).activate? %>
-  <p><%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch %></p>
-<% end %>
-<% if policy(@draw).update? %>
-  <p><%= link_to 'Add group to draw', new_draw_group_path(@draw) %></p>
-<% end %>
-<% if policy(@draw).destroy? %>
-  <p><%= link_to 'Delete', draw_path(@draw), method: :delete %></p>
-<% end %>
+<div>
+  <% if policy(@draw).student_summary? %>
+    <%= link_to 'View students', draw_student_summary_path(@draw), class: 'button secondary' %>
+  <% end %>
+  <% if policy(@draw).suite_summary? %>
+    <%= link_to 'View suites', draw_suite_summary_path(@draw), class: 'button secondary' %>
+  <% end %>
+  <% if policy(@draw).activate? %>
+    <%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch, class: 'button' %>
+  <% end %>
+  <% if policy(@draw).start_lottery? %>
+    <%= link_to 'Proceed to lottery', start_lottery_draw_path(@draw), method: :patch, class: 'button' %>
+  <% end %>
+  <% if policy(@draw).lottery? %>
+    <%= link_to 'Assign lottery numbers', draw_lottery_path(@draw), class: 'button secondary' %>
+  <% end %>
+  <% if policy(@draw).update? %>
+    <%= link_to 'Add group to draw', new_draw_group_path(@draw), class: 'button secondary' %>
+  <% end %>
+  <% if policy(@draw).destroy? %>
+    <%= link_to 'Delete', draw_path(@draw), method: :delete, class: 'button alert' %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   resources :enrollments, only: %i(new create)
 
   resources :draws do
+    member do
+      patch 'start_lottery'
+    end
     resources :groups do
       member do
         patch 'assign_lottery'

--- a/spec/features/draws/draw_start_lottery_spec.rb
+++ b/spec/features/draws/draw_start_lottery_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw start lottery' do
+  let(:draw) { FactoryGirl.create(:draw_with_members, status: 'pre_lottery') }
+  before do
+    log_in FactoryGirl.create(:admin)
+    FactoryGirl.create(:locked_group, leader: draw.students.first)
+  end
+
+  it 'can be done' do
+    visit draw_path(draw)
+    click_on 'Proceed to lottery'
+    expect(page).to have_css('.flash-success',
+                             text: 'You can now assign lottery numbers')
+  end
+end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe Draw, type: :model do
     end
   end
 
+  describe '#groups?' do
+    it 'returns true if the group_count is greater than zero' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:group_count).and_return(1)
+      expect(draw.groups?).to be_truthy
+    end
+
+    it 'returns false if the group_count is zero' do
+      draw = FactoryGirl.build_stubbed(:draw)
+      allow(draw).to receive(:group_count).and_return(0)
+      expect(draw.groups?).to be_falsey
+    end
+  end
+
   describe '#enough_beds?' do
     it 'returns true if bed_count >= student_count' do
       draw = FactoryGirl.build_stubbed(:draw)
@@ -101,5 +115,37 @@ RSpec.describe Draw, type: :model do
       draw = FactoryGirl.create(:draw, suites: [available, taken])
       expect(draw.available_suites).to eq([available])
     end
+  end
+
+  describe '#ungrouped_students' do
+    it 'returns true if there are students in the draw not in a group' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 2)
+      FactoryGirl.create(:group, leader: draw.students.first)
+      expect(draw.ungrouped_students?).to be_truthy
+    end
+    it 'returns false if there are no students in the draw not in a group' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 1)
+      FactoryGirl.create(:group, leader: draw.students.first)
+      expect(draw.ungrouped_students?).to be_falsey
+    end
+  end
+
+  describe '#all_groups_locked?' do
+    it 'returns true if all groups in the draw are locked' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 1)
+      FactoryGirl.create(:locked_group, leader: draw.students.first)
+      expect(draw.all_groups_locked?).to be_truthy
+    end
+    it 'returns false if not all groups in the draw are locked' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 2)
+      FactoryGirl.create(:locked_group, leader: draw.students.first)
+      FactoryGirl.create(:full_group, leader: draw.students.second)
+      expect(draw.all_groups_locked?).to be_falsey
+    end
+  end
+
+  describe '#no_contested_suites?' do
+    xit 'returns true if there are no suites contested in other draws'
+    xit 'returns false if there are any suites contested in other draws'
   end
 end

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -139,4 +139,36 @@ RSpec.describe Suite, type: :model do
       end
     end
   end
+
+  describe '#selectable?' do
+    it "returns true if the suite isn't selectable in another draw" do
+      suite = FactoryGirl.build_stubbed(:suite)
+      allow(suite).to receive(:draws)
+        .and_return(mock_draws(%i(pre_lottery? draft?)))
+      expect(suite).to be_selectable
+    end
+
+    it "returns false if one of the suite's draws is in the lottery phase" do
+      suite = FactoryGirl.build_stubbed(:suite)
+      allow(suite).to receive(:draws)
+        .and_return(mock_draws(%i(pre_lottery? draft? lottery?)))
+      expect(suite).not_to be_selectable
+    end
+
+    it 'returns false if a draw is in the suite_selection phase' do
+      suite = FactoryGirl.build_stubbed(:suite)
+      allow(suite).to receive(:draws)
+        .and_return(mock_draws(%i(pre_lottery? draft? suite_selection?)))
+      expect(suite).not_to be_selectable
+    end
+
+    def mock_draws(statuses)
+      default_statuses = { draft?: false, pre_lottery?: false, lottery?: false,
+                           suite_selection?: false }
+      statuses.map do |s|
+        status_hash = default_statuses.merge(s => true)
+        instance_spy('draw', **status_hash)
+      end
+    end
+  end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -157,6 +157,18 @@ RSpec.describe DrawPolicy do
       end
     end
 
+    permissions :start_lottery? do
+      context 'when draw is pre_lottery' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+
+      context 'when draw is not a draft' do
+        before { allow(draw).to receive(:pre_lottery?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
+
     permissions :intent_summary? do
       context 'when draw is a draft' do
         before { allow(draw).to receive(:draft?).and_return(true) }

--- a/spec/services/draw_lottery_starter_spec.rb
+++ b/spec/services/draw_lottery_starter_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe DrawLotteryStarter do
+  # we may want to extract this into a shared example if we use this pattern
+  # across all of our service objects
+  describe '.start' do
+    it 'calls :start on an instance of DrawStarter' do
+      draw = instance_spy('draw')
+      draw_lottery_starter = mock_draw_lottery_starter(draw: draw)
+      described_class.start(draw: draw)
+      expect(draw_lottery_starter).to have_received(:start)
+    end
+  end
+
+  describe '#start' do
+    it 'checks to make sure that the draw is in pre-lottery' do
+      draw = instance_spy('draw', pre_lottery?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('in the pre-lottery phase')
+    end
+
+    it 'checks to make sure that the draw has at least one group' do
+      draw = instance_spy('draw', groups?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('must have at least one group')
+    end
+
+    it 'checks to make sure that the draw has all locked groups' do
+      draw = instance_spy('draw', all_groups_locked?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('cannot have any unlocked groups')
+    end
+
+    it 'checks to make sure that the draw has no ungrouped students' do
+      draw = instance_spy('draw', ungrouped_students?: true, present?: true)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('cannot have any students not in groups')
+    end
+
+    it 'checks to make sure that there are enough beds for students' do
+      draw = instance_spy('draw', enough_beds?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('Draw must have at least one bed per student')
+    end
+
+    it 'checks to make sure that there are no contested suites' do
+      draw = instance_spy('draw', no_contested_suites?: false, nil?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('any suites in other draws that are in the lottery')
+    end
+
+    it 'checks to make sure that all groups are locked' do
+      draw = instance_spy('draw', all_groups_locked?: false, nil?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('cannot have any unlocked groups')
+    end
+
+    it 'updates the status of the draw to lottery' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update).with(status: 'lottery').and_return(true)
+      described_class.start(draw: draw)
+      expect(draw).to have_received(:update).with(status: 'lottery')
+    end
+
+    it 'checks to see if the update works' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update).and_return(false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('Draw update failed')
+    end
+
+    it 'returns the updated draw on success' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to eq(draw)
+    end
+
+    it 'sets the object key to nil in the hash on failure' do
+      draw = instance_spy('draw', validity_stubs(valid: false))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to be_nil
+    end
+  end
+
+  def mock_draw_lottery_starter(param_hash)
+    instance_spy('draw_lottery_starter').tap do |draw_lottery_starter|
+      allow(described_class).to receive(:new).with(param_hash)
+        .and_return(draw_lottery_starter)
+    end
+  end
+
+  def validity_stubs(valid:, **attrs)
+    {
+      pre_lottery?: valid, groups?: valid, enough_beds?: valid, present?: valid,
+      nil?: !valid, ungrouped_students?: !valid, no_contested_suites?: valid,
+      all_groups_locked?: valid
+    }.merge(attrs)
+  end
+end


### PR DESCRIPTION
Resolves #183
- Add DrawLotteryStarter
- Add Suite#selectable?
- Add Draw#groups? and a whole bunch of other query methods

Please make sure there's at least a pending test for all of the new Draw query methods.