### PR TITLE
[224] Add oversubscription handling to draws

### DIFF
--- a/app/assets/stylesheets/_draws.scss
+++ b/app/assets/stylesheets/_draws.scss
@@ -20,4 +20,12 @@
     text-align: center;
     a.button { margin: 0 }
   }
+
+  .group-size-header {
+    padding: 0.2em;
+    &.negative {
+      background-color: $alert-color;
+      color: white;
+    }
+  }
 }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -34,7 +34,7 @@ class GroupsController < ApplicationController
 
   def destroy
     result = Destroyer.new(object: @group, name_method: :name).destroy
-    handle_action(**result)
+    handle_action(**result, path: params[:redirect_path])
   end
 
   def request_to_join
@@ -135,6 +135,6 @@ class GroupsController < ApplicationController
     @group ||= Group.new(draw: @draw)
     @students = UngroupedStudentsQuery.new(@draw.students.on_campus).call
     @leader_students = @group.members.empty? ? @students : @group.members
-    @suite_sizes = @draw.suite_sizes
+    @suite_sizes = @draw.open_suite_sizes
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 # General view helper module
 module ApplicationHelper
-  include ActionView::Helpers::OutputSafetyHelper
+  delegate :size_str, to: Suite
+
   # Builds a Foundation tooltip around some content (
   #
   # @param text [String] the tooltip text
@@ -14,5 +15,13 @@ module ApplicationHelper
       data: { tooltip: true, 'disable-hover' => false }, title: text,
       aria: { haspopup: true }, class: "has-tip #{class_override}"
     }.merge(**overrides)
+  end
+
+  # Return a pluralized and capitalized named version of a suite / group size
+  #
+  # @param size [Integer] the suite / group size
+  # @return [String] the appropriate name
+  def headerize_size(size)
+    size_str(size).pluralize.capitalize
   end
 end

--- a/app/helpers/draws_helper.rb
+++ b/app/helpers/draws_helper.rb
@@ -2,8 +2,6 @@
 #
 # Helper module for Draws
 module DrawsHelper
-  delegate :size_str, to: Suite
-
   def intent_deadline_str(draw)
     diff = (draw.intent_deadline - Time.zone.today).to_i
     if diff.positive?
@@ -22,9 +20,48 @@ module DrawsHelper
     'zero'
   end
 
+  # Return the link to lock or unlock a specific group size for a draw
+  def toggle_size_lock_btn(draw:, size:, path:)
+    return lock_size_btn(draw, size, path) unless draw.size_locked?(size)
+    unlock_size_btn(draw, size, path)
+  end
+
+  # Return the link/button to proceed from the pre-lottery phase. Takes draw
+  # oversubscription status into account and modifies text and class as
+  # necessary.
+  #
+  # @param draw [Draw] the draw
+  # @return [String] the link
+  def proceed_from_pre_lottery_btn(draw)
+    options = if draw.oversubscribed?
+                { class: 'button alert', method: :patch }
+              else
+                { class: 'button', method: :patch }
+              end
+    link_to 'Proceed to lottery', start_lottery_draw_path(draw), **options
+  end
+
   private
 
   def day_str(n)
     "#{n} #{'day'.pluralize(n)}"
+  end
+
+  def lock_size_btn(draw, size, path)
+    link_to "Lock #{headerize_size(size)}",
+            toggle_size_lock_draw_path(draw, size, redirect_path: path),
+            method: :patch, **with_tooltip(
+              text: "Prevent students from forming more groups of size #{size}",
+              class_override: 'button', id: "lock-size-#{size}"
+            )
+  end
+
+  def unlock_size_btn(draw, size, path)
+    link_to "Unlock #{headerize_size(size)}",
+            toggle_size_lock_draw_path(draw, size, redirect_path: path),
+            method: :patch, **with_tooltip(
+              text: "Allow studenst to form groups of size #{size}",
+              class_overrides: 'button', id: "unlock-size-#{size}"
+            )
   end
 end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -2,8 +2,6 @@
 #
 # Helper methods for the Groups views
 module GroupsHelper
-  delegate :size_str, to: Suite
-
   # Generate the user listing for a group member; includes membership lock
   # status
   #

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,8 +2,6 @@
 #
 # Helper methods for the Users views
 module UsersHelper
-  delegate :size_str, to: Suite
-
   # Generate a form field for a profile attribute. Should be disabled if the
   # attribute is defined on the passed user object, and should include a hidden
   # field if disabled.

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -62,6 +62,14 @@ class DrawPolicy < ApplicationPolicy
     edit? && record.pre_lottery?
   end
 
+  def oversubscription?
+    start_lottery?
+  end
+
+  def toggle_size_lock?
+    edit?
+  end
+
   def lottery?
     record.lottery? && (user.admin? || user.rep?)
   end

--- a/app/queries/draw_sizes_query.rb
+++ b/app/queries/draw_sizes_query.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+#
+# Query to return all of the group and available suite sizes for a given draw.
+# Defaults to drawless groups if no draw passed.
+class DrawSizesQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize a new DrawSizesQuery, loads all arel tables as instance variables
+  def initialize
+    @draws = Draw.arel_table
+    @draws_suites = DrawsSuite.arel_table
+    @groups = Group.arel_table
+    @suites = Suite.arel_table
+  end
+
+  # Execute the draw sizes query, now with 100% more Arel!
+  #
+  # @param draw [Draw] the draw to collect sizes for, if nil collects draws
+  # @return [Array<Integer>] the group and available suite sizes in the relation
+  def call(draw: nil)
+    suite_base = draw ? draw_suite_base(draw) : global_suite_base
+    suite_query = suite_base.project(suites[:size]).distinct
+    overall_query = suite_query.union(group_query(draw))
+    ActiveRecord::Base.connection.select_values(overall_query.to_sql).sort
+  end
+
+  private
+
+  attr_reader :draws, :draws_suites, :groups, :suites
+
+  def draw_suite_base(draw) # rubocop:disable AbcSize
+    suites.join(draws_suites)
+          .on(draws_suites[:suite_id].eq(suites[:id]))
+          .where(draws_suites[:draw_id].eq(draw.id))
+          .where(available_suite)
+  end
+
+  def global_suite_base
+    suites.where(available_suite)
+  end
+
+  def available_suite
+    suites[:group_id].eq(nil)
+  end
+
+  def group_query(draw) # rubocop:disable AbcSize
+    groups.join(suites, Arel::Nodes::OuterJoin)
+          .on(suites[:group_id].eq(groups[:id]))
+          .where(groups[:draw_id].eq(draw.try(:id)))
+          .where(available_suite)
+          .project(groups[:size])
+          .distinct
+  end
+end

--- a/app/queries/group_sizes_query.rb
+++ b/app/queries/group_sizes_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+#
+# Query to return all of the group sizes in the database.
+class GroupSizesQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize a GroupSizesQuery
+  #
+  # @param relation [Group::ActiveRecord_Relation] the base relation for the
+  #   query
+  def initialize(relation = Group.all)
+    @relation = relation
+  end
+
+  # Execute the group sizes query
+  #
+  # @return [Array<Integer>] the group sizes in the relation
+  def call
+    @relation.select(:size).distinct.collect(&:size).sort
+  end
+end

--- a/app/services/draw_lottery_starter.rb
+++ b/app/services/draw_lottery_starter.rb
@@ -8,13 +8,13 @@ class DrawLotteryStarter
 
   attr_reader :draw
 
-  # validates :draw, presence: :true
-  validate :draw_in_pre_lottery_phase
-  validate :at_least_one_group
-  validate :no_ungrouped_students
-  validate :enough_beds
-  validate :no_contested_suites
-  validate :all_groups_locked
+  validate :draw_in_pre_lottery_phase, if: ->() { draw.present? }
+  validate :at_least_one_group, if: ->() { draw.present? }
+  validate :all_students_grouped, if: ->() { draw.present? }
+  validate :all_intents_declared, if: ->() { draw.present? }
+  validate :enough_beds, if: ->() { draw.present? }
+  validate :no_contested_suites, if: ->() { draw.present? }
+  validate :all_groups_locked, if: ->() { draw.present? }
 
   # Class method to permit calling :start on the class without instantiating the
   # service object directly
@@ -45,34 +45,39 @@ class DrawLotteryStarter
   attr_writer :draw
 
   def draw_in_pre_lottery_phase
-    return if draw.nil? || draw.pre_lottery?
+    return if draw.pre_lottery?
     errors.add(:draw, 'must be in the pre-lottery phase')
   end
 
   def at_least_one_group
-    return if draw.nil? || draw.groups?
+    return if draw.groups?
     errors.add(:draw, 'must have at least one group')
   end
 
-  def no_ungrouped_students
-    return unless draw.present? && draw.ungrouped_students?
+  def all_students_grouped
+    return if draw.all_students_grouped?
     errors.add(:draw, 'cannot have any students not in groups')
   end
 
+  def all_intents_declared
+    return if draw.all_intents_declared?
+    errors.add(:draw, 'cannot have any students who did not declare intent')
+  end
+
   def enough_beds
-    return if draw.nil? || draw.enough_beds?
+    return if draw.enough_beds?
     errors.add(:draw, 'must have at least one bed per student in all suites')
   end
 
   def no_contested_suites
-    return if draw.nil? || draw.no_contested_suites?
+    return if draw.no_contested_suites?
     errors.add(:draw,
                'cannot contain any suites in other draws that are in the '\
                'lottery or suite selection phase')
   end
 
   def all_groups_locked
-    return if draw.nil? || draw.all_groups_locked?
+    return if draw.all_groups_locked?
     errors.add(:draw, 'cannot have any unlocked groups')
   end
 

--- a/app/services/draw_size_lock_toggler.rb
+++ b/app/services/draw_size_lock_toggler.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+#
+# Service object to toggle whether or not a group size is locked for a given
+# draw. Validates that the size is one for which there are currently available
+# suites.
+class DrawSizeLockToggler
+  # permit calling :toggle on the base class
+  def self.toggle(**params)
+    new(**params).toggle
+  end
+
+  # Initialize a new DrawSizeLockToggler
+  #
+  # @param draw [Draw] the draw in question
+  # @param size_str [String] the size param passed in the request
+  def initialize(draw:, size:)
+    @draw = draw
+    @errors = []
+    @size = parse_size(size)
+  end
+
+  def toggle
+    return error(errors.join(', ')) unless valid?
+    toggle_size_lock
+    return success if draw.save
+    error(draw.errors.full_messages.join(', '))
+  end
+
+  private
+
+  attr_reader :draw, :size
+  attr_accessor :errors
+
+  def parse_size(size)
+    errors << "Invalid size #{size}" unless integer_string?(size)
+    size.to_i
+  end
+
+  def integer_string?(size)
+    /^\d+$/.match(size)
+  end
+
+  def valid?
+    errors.empty?
+  end
+
+  def toggle_size_lock
+    if draw.size_locked?(size)
+      draw.locked_sizes.delete_if { |s| s == size }
+    else
+      draw.locked_sizes << size
+    end
+  end
+
+  def success
+    { object: nil, msg: { success: success_msg } }
+  end
+
+  def error(errors)
+    { object: nil, msg: { error: "Draw update failed: #{errors}" } }
+  end
+
+  def success_msg
+    size_str = Suite.size_str(size).pluralize.capitalize
+    if draw.reload.size_locked?(size)
+      "#{size_str} locked"
+    else
+      "#{size_str} unlocked"
+    end
+  end
+end

--- a/app/views/buildings/_summary_table.html.erb
+++ b/app/views/buildings/_summary_table.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @suites_by_size[building.id].each do |size, suites| %>
       <tr>
-        <td data-role="suite-size"><%= size_str(size).capitalize.pluralize %></td>
+        <td data-role="suite-size"><%= headerize_size(size) %></td>
         <td data-role="suite-count"><%= suites.count %></td>
         <td data-role="assigned-count"><%= suites.reject { |s| s.group_id.nil? }.count %></td>
         <td data-role="draws-count"><%= suites.reject { |s| s.draws.empty? }.count %></td>

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -2,7 +2,7 @@
 <h2>Suites</h2>
 <% @suites.keys.each do |size| %>
   <div class="suites-list suites-<%= size_str(size).pluralize %>">
-    <h3><%= size_str(size).pluralize.titleize %></h3>
+    <h3><%= headerize_size(size) %></h3>
     <table>
       <thead>
         <tr>

--- a/app/views/drawless_groups/index.html.erb
+++ b/app/views/drawless_groups/index.html.erb
@@ -1,6 +1,5 @@
 <h1>Special Groups</h1>
 <div class="group-report">
-  <%= render 'draws/group_report', sizes: @sizes, groups: @groups_by_size,
-    actions_partial: 'drawless_groups/actions'  %>
+  <%= render 'draws/group_report', sizes: @sizes, groups: @groups_by_size, actions_partial: 'drawless_groups/actions', path: groups_path %>
 </div>
 <%= link_to 'New Special Group', new_group_path, class: 'button secondary' %>

--- a/app/views/draws/_group_report.html.erb
+++ b/app/views/draws/_group_report.html.erb
@@ -2,24 +2,31 @@
   <p>There are no groups yet.</p>
 <% else %>
   <% sizes.each do |size| %>
-    <h4><%= size_str(size).capitalize.pluralize %></h4>
-    <table>
-      <thead>
-        <tr>
-          <td>Group Leader</td>
-          <td>Status</td>
-          <td></td>
-        </tr>
-      </thead>
-      <tbody>
-        <% groups[size].each do |group| %>
-          <tr id="group-<%= group.id %>">
-            <td data-role="group-leader"><%= group.leader.full_name %></td>
-            <td data-role="group-status"><%= group.status.capitalize %></td>
-            <td data-role="group-actions"><%= render actions_partial, group: group %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <div class="groups-<%= size %>">
+      <h4><span class="group-size-header <%= diff_class(diff[size]) %>"><%= headerize_size(size) %> <%= " - #{pluralize(suite_counts[size], 'suite')}, #{pluralize(group_counts[size], 'group')}" %><%= ' (locked)' if @draw.size_locked?(size) %></span></h4>
+      <%= toggle_size_lock_btn(draw: @draw, size: size, path: path) if policy(@draw).toggle_size_lock? %>
+      <% if groups[size].empty? %>
+        <p>No groups of size <%= size %></p>
+      <% else %>
+        <table>
+          <thead>
+            <tr>
+              <td>Group Leader</td>
+              <td>Status</td>
+              <td></td>
+            </tr>
+          </thead>
+          <tbody>
+            <% groups[size].each do |group| %>
+              <tr id="group-<%= group.id %>">
+                <td data-role="group-leader"><%= group.leader.full_name %></td>
+                <td data-role="group-status"><%= group.status.capitalize %></td>
+                <td data-role="group-actions"><%= render actions_partial, group: group, path: path %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+    </div>
   <% end %>
+<% end %>
 <% end %>

--- a/app/views/draws/_oversub_report.html.erb
+++ b/app/views/draws/_oversub_report.html.erb
@@ -1,4 +1,5 @@
 <h3>Draw Summary</h3>
+<%= link_to 'Handle oversubscription', oversub_draw_path(draw), class: 'button' if draw.oversubscribed? && policy(draw).oversubscription? %>
 <table>
   <thead>
     <tr>

--- a/app/views/draws/_suite_report.html.erb
+++ b/app/views/draws/_suite_report.html.erb
@@ -4,7 +4,7 @@
 <ul style="list-style-type: none;">
   <% @suite_sizes.each do |size| %>
     <li>
-      <%= "#{size_str(size).pluralize.capitalize} - #{@suite_counts[size]}" %>
+      <%= "#{headerize_size(size)} - #{@suite_counts[size]}" %>
     </li>
   <% end %>
 </ul>

--- a/app/views/draws/oversubscription.html.erb
+++ b/app/views/draws/oversubscription.html.erb
@@ -1,0 +1,8 @@
+<h1><%= @draw.name %> - Oversubscription handling</h1>
+<div class="group-report">
+    <%= render 'group_report', sizes: @draw_sizes, groups: @groups_by_size, 
+                               diff: @diff, group_counts: @group_counts,
+                               suite_counts: @suite_counts, actions_partial: 'groups/actions',
+                               path: oversub_draw_path(@draw) %>
+</div>
+<%= link_to 'Back to draw', draw_path(@draw) %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -1,23 +1,30 @@
 <h1 class="draw-name"><%= @draw.name %></h1>
 <% if @draw.draft? %>
-<div class="suite-report">
+  <div class="suite-report">
     <%= render 'suite_report' %>
-</div>
+  </div>
+  <hr />
 <% end %>
 <% if policy(@draw).oversub_report? %>
   <div class="oversub-report">
-    <%= render 'oversub_report' %>
+    <%= render 'oversub_report', draw: @draw %>
   </div>
+  <hr />
 <% end %>
 <% if policy(@draw).group_report? %>
   <div class="group-report">
     <h3>Group Report</h3>
-    <%= render 'group_report', sizes: @suite_sizes, groups: @groups_by_size, actions_partial: 'groups/actions' %>
+    <%= render 'group_report', sizes: @draw_sizes, groups: @groups_by_size, 
+                               diff: @diff, group_counts: @group_counts,
+                               suite_counts: @suite_counts, actions_partial: 'groups/actions',
+                               path: draw_path(@draw) %>
   </div>
+  <hr />
 <% end %>
 <div class="ungrouped-report">
   <%= render 'ungrouped_report' %>
 </div>
+<hr />
 <% if policy(@draw).intent_summary? %>
   <div class="intent-metrics">
     <h3>Intent Metrics</h3>
@@ -38,6 +45,7 @@
       <p><%= link_to 'View intent report', intent_report_draw_path(@draw) %></p>
     <% end %>
   </div>
+  <hr />
 <% end %>
 <div>
   <% if policy(@draw).student_summary? %>
@@ -54,7 +62,7 @@
     <%= link_to 'Begin draw process', activate_draw_path(@draw), method: :patch, class: 'button' %>
   <% end %>
   <% if policy(@draw).start_lottery? %>
-    <%= link_to 'Proceed to lottery', start_lottery_draw_path(@draw), method: :patch, class: 'button' %>
+    <%= proceed_from_pre_lottery_btn(@draw) %>
   <% end %>
   <% if policy(@draw).start_selection? %>
     <%= link_to 'Start suite selection', start_selection_draw_path(@draw), method: :patch, class: 'button' %>

--- a/app/views/draws/suite_summary.html.erb
+++ b/app/views/draws/suite_summary.html.erb
@@ -1,7 +1,7 @@
 <h1 class="draw-name"><%= @draw.name %> Suites</h1>
 <% @all_sizes.each do |size| %>
   <div class="suites-list suites-<%= size_str(size).pluralize %>">
-    <h2><%= size_str(size).pluralize.titleize %> <%= link_to 'Edit', suites_edit_draw_path(@draw, size), id: "edit-suites-#{size}", clasS: 'draw-edit-suites' if policy(@draw).suites_edit? %></h2>
+    <h2><%= headerize_size(size) %> <%= link_to 'Edit', suites_edit_draw_path(@draw, size), id: "edit-suites-#{size}", class: 'draw-edit-suites' if policy(@draw).suites_edit? %></h2>
     <% if @suites_by_size.has_key? size %>
       <% @suites_by_size[size].each do |suite| %>
         <div class="suite-item"><%= link_to suite.number, suite_path(suite) %></div>

--- a/app/views/groups/_actions.html.erb
+++ b/app/views/groups/_actions.html.erb
@@ -3,5 +3,5 @@
   <%= link_to 'Edit', edit_draw_group_path(@draw, group), class: 'button' %>
 <% end %>
 <% if policy(group).destroy? %>
-  <%= link_to 'Disband', draw_group_path(@draw, group), method: :delete, class: 'button alert' %>
+  <%= link_to 'Disband', draw_group_path(@draw, group, redirect_path: path), method: :delete, class: 'button alert' %>
 <% end %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -4,3 +4,4 @@
 <% content_for :sidebar do %>
   <h3>Insert Draw Summary here</h3>
 <% end %>
+<%= link_to 'Back to draw', draw_path(@draw) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
       get 'students', to: 'draws#student_summary', as: 'student_summary'
       patch 'students', to: 'draws#students_update', as: 'students_update'
       patch 'start_lottery'
+      get 'oversubscription', to: 'draws#oversubscription', as: 'oversub'
+      patch 'size_lock/:size', to: 'draws#toggle_size_lock',
+                               as: 'toggle_size_lock'
       get 'lottery'
       patch 'start_selection'
     end

--- a/spec/factories/draws.rb
+++ b/spec/factories/draws.rb
@@ -15,6 +15,17 @@ FactoryGirl.define do
         create_list(:student, e.students_count, draw: draw)
       end
 
+      factory :oversubscribed_draw do
+        after(:create) do |draw, e|
+          e.groups_count.times do
+            l = FactoryGirl.create(:student, draw: draw, intent: 'on_campus')
+            FactoryGirl.create(:locked_group, size: 1, leader: l)
+          end
+          draw.suites.delete_all
+          draw.update(status: 'pre_lottery')
+        end
+      end
+
       factory :draw_in_lottery do
         after(:create) do |draw, e|
           suites = create_list(:suite_with_rooms, e.groups_count, draws: [draw])

--- a/spec/features/draws/draw_oversubscription_handling_spec.rb
+++ b/spec/features/draws/draw_oversubscription_handling_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw oversubscription handling' do
+  let(:draw) do
+    FactoryGirl.create(:draw_with_members, students_count: 2,
+                                           status: 'pre_lottery')
+  end
+  let!(:group) do
+    FactoryGirl.create(:locked_group, leader: draw.students.first, size: 1)
+  end
+  before do
+    FactoryGirl.create(:locked_group, leader: draw.students.last, size: 1)
+    draw.suites.delete_all
+    draw.suites << FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    draw.suites << FactoryGirl.create(:suite_with_rooms, rooms_count: 2)
+    log_in FactoryGirl.create(:admin)
+  end
+
+  it 'is used as a confirmation for lottery assignment' do
+    visit draw_path(draw)
+    click_on 'Handle oversubscription'
+    expect(page).to have_content('Oversubscription handling')
+  end
+
+  it 'allows admins to disband groups' do
+    visit draw_path(draw)
+    click_on 'Handle oversubscription'
+    disband_group(group)
+    expect(page).to have_css('.flash-notice', text: /Group.+deleted/)
+  end
+
+  it 'allows admins to lock suite sizes' do
+    visit draw_path(draw)
+    within('.groups-1') { click_on 'Lock Singles' }
+    expect(page).to have_css('.flash-success', text: /Singles locked/)
+  end
+
+  def disband_group(group)
+    within("tr#group-#{group.id}") do
+      click_on 'Disband'
+    end
+  end
+end

--- a/spec/features/draws/draw_oversubscription_report_spec.rb
+++ b/spec/features/draws/draw_oversubscription_report_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature 'Draw oversubscription dashboard' do
+RSpec.feature 'Draw oversubscription report' do
   let(:draw) do
     FactoryGirl.create(:draw_with_members, students_count: 2, suites_count: 1,
                                            status: 'pre_lottery')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,4 +17,11 @@ RSpec.describe ApplicationHelper, type: :helper do
         match(expected)
     end
   end
+
+  describe '#headerize_size' do
+    it 'returns a capitalized, pluralized version of the suite string' do
+      allow(helper).to receive(:size_str).with(1).and_return('single')
+      expect(helper.headerize_size(1)).to eq('Singles')
+    end
+  end
 end

--- a/spec/helpers/draws_helper_spec.rb
+++ b/spec/helpers/draws_helper_spec.rb
@@ -41,4 +41,32 @@ RSpec.describe DrawsHelper, type: :helper do
       expect(helper.diff_class(-1)).to eq('negative')
     end
   end
+
+  describe '#toggle_size_lock_btn' do
+    let(:draw) { instance_spy('draw') }
+    it 'returns a lock button if the draw size is unlocked' do
+      allow(draw).to receive(:size_locked?).and_return(false)
+      btn = helper.toggle_size_lock_btn(draw: draw, size: 1, path: '')
+      expect(btn).to include('Lock Singles')
+    end
+    it 'returns an unlock button if the draw size is locked' do
+      allow(draw).to receive(:size_locked?).and_return(true)
+      btn = helper.toggle_size_lock_btn(draw: draw, size: 1, path: '')
+      expect(btn).to include('Unlock Singles')
+    end
+  end
+
+  describe '#proceed_from_pre_lottery_btn' do
+    let(:draw) { instance_spy('draw') }
+    it 'returns a red button for oversubscription' do
+      allow(draw).to receive(:oversubscribed?).and_return(true)
+      expect(helper.proceed_from_pre_lottery_btn(draw)).to \
+        match(/class=\"button alert\".+Proceed to lottery/)
+    end
+    it 'returns a blue button for not oversubscription' do
+      allow(draw).to receive(:oversubscribed?).and_return(false)
+      expect(helper.proceed_from_pre_lottery_btn(draw)).to \
+        match(/class=\"button\".+Proceed to lottery/)
+    end
+  end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe DrawPolicy do
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
                 :suites_update?, :student_summary?, :students_update?,
-                :start_lottery?, :start_selection?, :bulk_on_campus? do
+                :oversubscription?, :toggle_size_lock?, :start_lottery?,
+                :start_selection?, :bulk_on_campus? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -73,7 +74,8 @@ RSpec.describe DrawPolicy do
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
                 :suites_update?, :student_summary?, :students_update?,
-                :start_lottery?, :start_selection?, :bulk_on_campus? do
+                :oversubscription?, :toggle_size_lock?, :start_lottery?,
+                :start_selection?, :bulk_on_campus? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :index? do
@@ -140,7 +142,7 @@ RSpec.describe DrawPolicy do
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
                 :filter_intent_report?, :group_actions?, :suite_summary?,
                 :suites_edit?, :suites_update?, :student_summary?,
-                :students_update? do
+                :students_update?, :toggle_size_lock? do
       it { is_expected.to permit(user, draw) }
     end
     permissions :index?, :new?, :create? do
@@ -159,7 +161,7 @@ RSpec.describe DrawPolicy do
       end
     end
 
-    permissions :start_lottery? do
+    permissions :start_lottery?, :oversubscription? do
       context 'when draw is pre_lottery' do
         before { allow(draw).to receive(:pre_lottery?).and_return(true) }
         it { is_expected.to permit(user, draw) }

--- a/spec/queries/draw_sizes_query_spec.rb
+++ b/spec/queries/draw_sizes_query_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawSizesQuery do
+  it 'returns an array of all ungrouped suite and group sizes for a draw' do
+    expected = [1, 2, 3, 5]
+    create_groups([1, 1, 2, 3])
+    create_suites([5])
+    expect(described_class.call).to eq(expected)
+  end
+
+  it 'restricts group query to specific draw if passed' do
+    draw = FactoryGirl.create(:draw)
+    create_groups([1, 2], draw)
+    create_groups([3])
+    expect(described_class.call(draw: draw)).to eq([1, 2])
+  end
+
+  it 'restricts suite query to specific draw if passed' do
+    draw = FactoryGirl.create(:draw)
+    create_suites([1, 2], draw)
+    create_suites([3])
+    expect(described_class.call(draw: draw)).to eq([1, 2])
+  end
+
+  it 'sorts the resulting array' do
+    create_groups([3, 1, 2])
+    expect(described_class.call).to eq([1, 2, 3])
+  end
+
+  def create_groups(sizes, draw = nil)
+    sizes.each do |size|
+      group = FactoryGirl.create(:full_group, size: size)
+      if draw
+        group.members.each { |u| u.update(draw_id: draw.id) }
+        group.update_column(:draw_id, draw.id)
+      end
+    end
+  end
+
+  def create_suites(sizes, draw = nil)
+    sizes.each do |size|
+      suite = FactoryGirl.create(:suite_with_rooms, rooms_count: size)
+      draw.suites << suite if draw
+    end
+  end
+end

--- a/spec/queries/group_sizes_query_spec.rb
+++ b/spec/queries/group_sizes_query_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GroupSizesQuery do
+  it 'returns an array of all unique suite sizes in the passed relation' do
+    expected = [1, 2]
+    create_groups([1, 1, 2, 3])
+    relation = Group.where(size: expected)
+    expect(described_class.new(relation).call).to eq(expected)
+  end
+
+  it 'returns an array of all unique suite sizes if no relation passed' do
+    expected = [1, 2]
+    create_groups(expected)
+    expect(described_class.call).to eq(expected)
+  end
+
+  it 'sorts the resulting array' do
+    create_groups([3, 1, 2])
+    expect(described_class.call).to eq([1, 2, 3])
+  end
+
+  def create_groups(sizes)
+    sizes.each do |size|
+      FactoryGirl.create(:full_group, size: size)
+    end
+  end
+end

--- a/spec/services/draw_lottery_starter_spec.rb
+++ b/spec/services/draw_lottery_starter_spec.rb
@@ -15,47 +15,54 @@ RSpec.describe DrawLotteryStarter do
 
   describe '#start' do
     it 'checks to make sure that the draw is in pre-lottery' do
-      draw = instance_spy('draw', pre_lottery?: false)
+      draw = instance_spy('draw', pre_lottery?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to include('in the pre-lottery phase')
     end
 
     it 'checks to make sure that the draw has at least one group' do
-      draw = instance_spy('draw', groups?: false)
+      draw = instance_spy('draw', groups?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to \
         include('must have at least one group')
     end
 
     it 'checks to make sure that the draw has all locked groups' do
-      draw = instance_spy('draw', all_groups_locked?: false)
+      draw = instance_spy('draw', all_groups_locked?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to include('cannot have any unlocked groups')
     end
 
     it 'checks to make sure that the draw has no ungrouped students' do
-      draw = instance_spy('draw', ungrouped_students?: true, present?: true)
+      draw = instance_spy('draw', all_students_grouped?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to \
         include('cannot have any students not in groups')
     end
 
+    it 'checks to make sure that the draw has no undeclared students' do
+      draw = instance_spy('draw', all_intents_declared?: false, present?: true)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('cannot have any students who did not declare intent')
+    end
+
     it 'checks to make sure that there are enough beds for students' do
-      draw = instance_spy('draw', enough_beds?: false)
+      draw = instance_spy('draw', enough_beds?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to \
         include('Draw must have at least one bed per student')
     end
 
     it 'checks to make sure that there are no contested suites' do
-      draw = instance_spy('draw', no_contested_suites?: false, nil?: false)
+      draw = instance_spy('draw', no_contested_suites?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to \
         include('any suites in other draws that are in the lottery')
     end
 
     it 'checks to make sure that all groups are locked' do
-      draw = instance_spy('draw', all_groups_locked?: false, nil?: false)
+      draw = instance_spy('draw', all_groups_locked?: false, present?: true)
       result = described_class.start(draw: draw)
       expect(result[:msg][:error]).to \
         include('cannot have any unlocked groups')
@@ -97,9 +104,9 @@ RSpec.describe DrawLotteryStarter do
 
   def validity_stubs(valid:, **attrs)
     {
-      pre_lottery?: valid, groups?: valid, enough_beds?: valid, present?: valid,
-      nil?: !valid, ungrouped_students?: !valid, no_contested_suites?: valid,
-      all_groups_locked?: valid
+      pre_lottery?: valid, groups?: valid, enough_beds?: valid, nil?: !valid,
+      all_students_grouped?: valid, no_contested_suites?: valid,
+      all_groups_locked?: valid, all_intents_declared?: valid
     }.merge(attrs)
   end
 end

--- a/spec/services/draw_size_lock_toggler_spec.rb
+++ b/spec/services/draw_size_lock_toggler_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe DrawSizeLockToggler do
+  describe '.toggle' do
+    xit 'calls :toggle on an instance of DrawSizeLockToggler'
+  end
+
+  describe '#toggle' do
+    let(:draw) { FactoryGirl.create(:draw_with_members) }
+    context 'success' do
+      it 'locks the size when unlocked' do
+        expect { described_class.toggle(draw: draw, size: '1') }.to \
+          change { draw.size_locked?(1) }
+      end
+      it 'unlocks the size when locked' do
+        draw.update(locked_sizes: [1])
+        expect { described_class.toggle(draw: draw, size: '1') }.to \
+          change { draw.size_locked?(1) }
+      end
+      it 'sets :object to nil' do
+        result = described_class.toggle(draw: draw, size: '1')
+        expect(result[:object]).to be_nil
+      end
+      it 'sets a success flash message' do
+        result = described_class.toggle(draw: draw, size: '1')
+        expect(result[:msg].keys).to eq([:success])
+      end
+    end
+
+    context 'failure' do
+      it 'ensures that an integer is passed' do
+        expect { described_class.toggle(draw: draw, size: 'a') }.not_to \
+          change { draw.locked_sizes }
+      end
+      it 'sets :object to nil' do
+        result = described_class.toggle(draw: draw, size: 'a')
+        expect(result[:object]).to be_nil
+      end
+      it 'sets an error flash message' do
+        result = described_class.toggle(draw: draw, size: 'a')
+        expect(result[:msg].keys).to eq([:error])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #224
- Redirect lottery start requests to oversubscription page if draw is oversubscribed, but can be bypassed even while oversubscribed
- Add Draw#oversubscribed? and Draw#size_locked?
- Add GroupSizesQuery
- Add DrawSizesQuery (yay Arel)
- Allow group disbanding requests to take a path to redirect to
- Add draw size locking route (also takes a redirect path via params)
- Add DrawsHelper#toggle_size_lock_btn