### PR TITLE
[209] Add transition to suite selection for draws

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -3,7 +3,8 @@
 # Controller for Draws
 class DrawsController < ApplicationController # rubocop:disable ClassLength
   prepend_before_action :set_draw, except: %i(index new create)
-  before_action :calculate_metrics, only: %i(show activate start_lottery)
+  before_action :calculate_metrics, only: %i(show activate start_lottery
+                                             start_selection)
 
   def show; end
 
@@ -122,6 +123,11 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
   end
 
   def lottery; end
+
+  def start_selection
+    result = DrawSelectionStarter.start(draw: @draw)
+    handle_action(action: 'show', **result)
+  end
 
   private
 

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -62,6 +62,10 @@ class DrawPolicy < ApplicationPolicy
     record.lottery? && (user.admin? || user.rep?)
   end
 
+  def start_selection?
+    edit? && record.lottery? && record.lottery_complete?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/services/draw_selection_starter.rb
+++ b/app/services/draw_selection_starter.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+#
+# Service object to handle the starting of the lottery phase for a draw. Checks
+# to make sure that the draw has the correct status and has enough beds for
+# students, as well as no ungrouped students, and updates the status.
+class DrawSelectionStarter
+  include ActiveModel::Model
+
+  attr_reader :draw
+
+  # validates :draw, presence: :true
+  validate :draw_in_lottery_phase
+  validate :lottery_complete
+
+  # Class method to permit calling :start on the class without instantiating the
+  # service object directly
+  def self.start(**params)
+    new(**params).start
+  end
+
+  # Initialize a new DrawSelectionStarter
+  #
+  # @param draw [Draw] the draw in question
+  def initialize(draw:)
+    @draw = draw
+  end
+
+  # Start the lottery phase of a Draw
+  #
+  # @return [Hash{Symbol=>ApplicationRecord,Hash}] A results hash with the
+  #   message to set in the flash and either `nil` or the modified object.
+  def start
+    return error unless valid?
+    return success if draw.update(status: 'suite_selection')
+    errors.add(:base, 'Draw update failed')
+    error
+  end
+
+  private
+
+  attr_writer :draw
+
+  def draw_in_lottery_phase
+    return if draw.nil? || draw.lottery?
+    errors.add(:draw, 'must be in the lottery phase')
+  end
+
+  def lottery_complete
+    return if draw.nil? || draw.lottery_complete?
+    errors.add(:base, 'All groups must have lottery numbers assigned')
+  end
+
+  def success
+    { object: draw, msg: { success: 'Suite selection started' } }
+  end
+
+  def error
+    msg = "There was a problem starting suite selection:\n#{error_msgs}"
+    { object: nil, msg: { error: msg } }
+  end
+
+  def error_msgs
+    errors.full_messages.join(', ')
+  end
+end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -52,6 +52,9 @@
   <% if policy(@draw).start_lottery? %>
     <%= link_to 'Proceed to lottery', start_lottery_draw_path(@draw), method: :patch, class: 'button' %>
   <% end %>
+  <% if policy(@draw).start_selection? %>
+    <%= link_to 'Start suite selection', start_selection_draw_path(@draw), method: :patch, class: 'button' %>
+  <% end %>
   <% if policy(@draw).lottery? %>
     <%= link_to 'Assign lottery numbers', lottery_draw_path(@draw), class: 'button secondary' %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,6 @@ Rails.application.routes.draw do
   resources :draws do
     member do
       patch 'activate'
-      patch 'start_lottery'
       get 'intent_report'
       post 'intent_report', to: 'draws#filter_intent_report'
       get 'suites', to: 'draws#suite_summary', as: 'suite_summary'
@@ -39,7 +38,9 @@ Rails.application.routes.draw do
       patch 'suites', to: 'draws#suites_update', as: 'suites_update'
       get 'students', to: 'draws#student_summary', as: 'student_summary'
       patch 'students', to: 'draws#students_update', as: 'students_update'
+      patch 'start_lottery'
       get 'lottery'
+      patch 'start_selection'
     end
 
     resources :groups do

--- a/spec/features/draws/draw_start_selection_spec.rb
+++ b/spec/features/draws/draw_start_selection_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Draw start selection' do
+  let(:draw) { FactoryGirl.create(:draw_in_lottery) }
+  before do
+    log_in FactoryGirl.create(:admin)
+    draw.groups.each { |g| g.update(lottery_number: 1) }
+  end
+
+  it 'can be done' do
+    visit draw_path(draw)
+    click_on 'Start suite selection'
+    expect(page).to have_css('.flash-success', text: 'Suite selection started')
+  end
+end

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe Draw, type: :model do
       FactoryGirl.create(:group, leader: draw.students.first)
       expect(draw.ungrouped_students?).to be_truthy
     end
+    it 'checks for undeclared students' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 2)
+      FactoryGirl.create(:group, leader: draw.students.first)
+      draw.students.last.update(intent: 'undeclared')
+      expect(draw.ungrouped_students?).to be_truthy
+    end
+    it 'ignores off_campus students' do
+      draw = FactoryGirl.create(:draw_with_members, students_count: 2)
+      FactoryGirl.create(:group, leader: draw.students.first)
+      draw.students.last.update(intent: 'off_campus')
+      expect(draw.ungrouped_students?).to be_falsey
+    end
     it 'returns false if there are no students in the draw not in a group' do
       draw = FactoryGirl.create(:draw_with_members, students_count: 1)
       FactoryGirl.create(:group, leader: draw.students.first)
@@ -151,5 +163,16 @@ RSpec.describe Draw, type: :model do
 
   describe '#student_count' do
     xit 'returns the nuber of students in the draw'
+  end
+
+  describe '#lottery_complete?' do
+    let(:draw) { FactoryGirl.create(:draw_in_lottery) }
+    it 'returns true if all groups have lottery numbers assigned' do
+      draw.groups.each { |g| g.update(lottery_number: 1) }
+      expect(draw.lottery_complete?).to be_truthy
+    end
+    it 'returns false if some groups do have lottery numbers assigned' do
+      expect(draw.lottery_complete?).to be_falsey
+    end
   end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe DrawPolicy do
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
-                :suites_update?, :student_summary?, :students_update? do
+                :suites_update?, :student_summary?, :students_update?,
+                :start_lottery?, :start_selection? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -71,7 +72,8 @@ RSpec.describe DrawPolicy do
     end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
-                :suites_update?, :student_summary?, :students_update? do
+                :suites_update?, :student_summary?, :students_update?,
+                :start_lottery?, :start_selection? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :index? do
@@ -165,6 +167,29 @@ RSpec.describe DrawPolicy do
 
       context 'when draw is not a draft' do
         before { allow(draw).to receive(:pre_lottery?).and_return(false) }
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
+
+    permissions :start_selection? do
+      context 'when draw is in lottery and all numbers assigned' do
+        before do
+          allow(draw).to receive(:lottery?).and_return(true)
+          allow(draw).to receive(:lottery_complete?).and_return(true)
+        end
+        it { is_expected.to permit(user, draw) }
+      end
+      context 'when draw is in lottery but not all numbers assigned' do
+        before do
+          allow(draw).to receive(:lottery?).and_return(true)
+          allow(draw).to receive(:lottery_complete?).and_return(false)
+        end
+        it { is_expected.not_to permit(user, draw) }
+      end
+      context 'when draw is not in lottery' do
+        before do
+          allow(draw).to receive(:lottery?).and_return(false)
+        end
         it { is_expected.not_to permit(user, draw) }
       end
     end

--- a/spec/services/draw_selection_starter_spec.rb
+++ b/spec/services/draw_selection_starter_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe DrawSelectionStarter do
+  # we may want to extract this into a shared example if we use this pattern
+  # across all of our service objects
+  describe '.start' do
+    it 'calls :start on an instance of DrawStarter' do
+      draw = instance_spy('draw')
+      draw_selection_starter = mock_draw_selection_starter(draw: draw)
+      described_class.start(draw: draw)
+      expect(draw_selection_starter).to have_received(:start)
+    end
+  end
+
+  describe '#start' do
+    it 'checks to make sure that the draw is in lottery' do
+      draw = instance_spy('draw', lottery?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('in the lottery phase')
+    end
+
+    it 'checks to make sure that all groups have lottery numbers assigned' do
+      draw = instance_spy('draw', lottery_complete?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to \
+        include('All groups must have lottery numbers assigned')
+    end
+
+    it 'updates the status of the draw to suite_selection' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update).with(status: 'suite_selection')
+        .and_return(true)
+      described_class.start(draw: draw)
+      expect(draw).to have_received(:update).with(status: 'suite_selection')
+    end
+
+    it 'checks to see if the update works' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update).and_return(false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('Draw update failed')
+    end
+
+    it 'returns the updated draw on success' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to eq(draw)
+    end
+
+    it 'sets the object key to nil in the hash on failure' do
+      draw = instance_spy('draw', validity_stubs(valid: false))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to be_nil
+    end
+  end
+
+  def mock_draw_selection_starter(param_hash)
+    instance_spy('draw_selection_starter').tap do |draw_selection_starter|
+      allow(described_class).to receive(:new).with(param_hash)
+        .and_return(draw_selection_starter)
+    end
+  end
+
+  def validity_stubs(valid:, **attrs)
+    { lottery?: valid, lottery_complete?: valid }.merge(attrs)
+  end
+end


### PR DESCRIPTION
Resolves #209
- Add `Draw#lottery_complete?`
- Fix bug with `Draw#ungrouped_students?` (it now only looks at undeclared and on_campus students
- Add start_selection route and `DrawSelectionStarter` service object