### PR TITLE
[351] Set up Mail config to support optional authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,13 @@
 # EXECJS_RUNTIME=Node
 # SMTP_ADDRESS=smtp.example.com
 # SMTP_DOMAIN=example.com
+# SMTP_PORT=587
+# SMTP_AUTH=login (used as the authentication parameter for Mail settings,
+#   disables authentication if missing)
 # SMTP_PASSWORD=password
 # SMTP_USERNAME=username
+# EMAIL_RECIPIENTS=foo@example.com (used to intercept all e-mails in test /
+#   staging environments, will redirect them to the passed e-mail address)
 # WEB_CONCURRENCY=1
 # HONEYBADGER_API=[Honeybadger API Key]
 # SKYLIGHT_API=[Skylight API Key]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable BlockLength
 require Rails.root.join('config/smtp')
 Rails.application.configure do
   if ENV.fetch('HEROKU_APP_NAME', '').include?('staging-pr-')
@@ -16,6 +17,7 @@ Rails.application.configure do
                                                   ENV.fetch('APPLICATION_HOST'))
   config.log_level = :debug
   config.log_tags = [:request_id]
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = SMTP_SETTINGS

--- a/config/smtp.rb
+++ b/config/smtp.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
+auth_settings = if ENV['SMTP_AUTH'].present?
+                  {
+                    authentication: ENV.fetch('SMTP_AUTH').to_sym,
+                    user_name: ENV.fetch('SMTP_USERNAME'),
+                    password: ENV.fetch('SMTP_PASSWORD')
+                  }
+                else
+                  {}
+                end
+
 SMTP_SETTINGS = {
   address: ENV.fetch('SMTP_ADDRESS'), # example: "smtp.sendgrid.net"
-  authentication: :plain,
   domain: ENV.fetch('SMTP_DOMAIN'), # example: "heroku.com"
   enable_starttls_auto: true,
-  password: ENV.fetch('SMTP_PASSWORD'),
-  port: '587',
-  user_name: ENV.fetch('SMTP_USERNAME')
-}.freeze
+  port: ENV.fetch('SMTP_PORT')
+}.merge(auth_settings).freeze
 
 if ENV['EMAIL_RECIPIENTS'].present?
   Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])


### PR DESCRIPTION
Resolves #351
- Add documentation of additional parameters to .env.example
- Mailer delivery errors will now raise

On the INF side, we can currently only send to `@yale.edu` e-mail addresses if we go through the Yale mailserver. If we want full-functioned mailing we'll have to set up SES.