### PR TITLE
[326] Add medical suite flag

### DIFF
--- a/app/controllers/suites_controller.rb
+++ b/app/controllers/suites_controller.rb
@@ -75,7 +75,7 @@ class SuitesController < ApplicationController
   end
 
   def suite_params
-    params.require(:suite).permit(:number, :building_id)
+    params.require(:suite).permit(:number, :building_id, :medical)
   end
 
   def suite_merger_params

--- a/app/helpers/suites_helper.rb
+++ b/app/helpers/suites_helper.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+#
+# Helper module for Suites
+module SuitesHelper
+  # Sets the value for the hidden field on the medical suite "form"
+  #
+  # @param suite [Suite] the suite in question
+  # @return [Integer] a value inverse of the current medical status
+  def medical_val(suite)
+    suite.medical ? 0 : 1
+  end
+
+  # Returns the button string for the medical suite "form"
+  #
+  # @param suite [Suite] the suite in question
+  # @return [String] the button string
+  def medical_btn_str(suite)
+    "Make #{medical_str(!suite.medical)}"
+  end
+
+  # Returns a suite describing a suite based on its medical flag
+  #
+  # @param medical [Boolean] whether or not the suite is a medical suite
+  # @return [String] the string describing it
+  def medical_str(medical)
+    prefix = medical ? '' : 'non-'
+    "#{prefix}medical suite"
+  end
+end

--- a/app/views/suites/_form.html.erb
+++ b/app/views/suites/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @suite do |f| %>
   <%= f.input :number %>
   <%= f.association :building %>
+  <%= f.input :medical, label: 'Medical suite' %>
   <%= f.submit %>
 <% end %>

--- a/app/views/suites/_medical_form.html.erb
+++ b/app/views/suites/_medical_form.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for suite do |f| %>
+  <%= f.input :medical, as: :hidden, input_html: { value: medical_val(suite) } %>
+  <%= f.submit medical_btn_str(suite), class: 'primary' %>
+<% end %>

--- a/app/views/suites/show.html.erb
+++ b/app/views/suites/show.html.erb
@@ -1,4 +1,7 @@
 <h1 class="suite-number"><%= @suite.number %></h1>
+  <% if policy(@suite).edit? %>
+    <span class="label secondary suite-medical" style="margin-bottom: 1em;"><%= medical_str(@suite.medical).capitalize %></span>
+  <% end %>
 <ul>
   <li>Status:
     <% if @suite.available? %>
@@ -37,4 +40,10 @@
 <% if policy(@suite).split? %>
   <p><%= link_to 'Split suite', split_suite_path(@suite) %></p>
 <% end %>
-<p><%= link_to 'Delete', suite_path(@suite), method: :delete %></p>
+
+<% if policy(@suite).edit? %>
+  <div>
+    <%= render 'medical_form', suite: @suite %>
+    <%= link_to 'Delete', suite_path(@suite), method: :delete, class: 'button alert' %>
+  </div>
+ <% end %>

--- a/db/migrate/20170311014302_add_medical_to_suites.rb
+++ b/db/migrate/20170311014302_add_medical_to_suites.rb
@@ -1,0 +1,5 @@
+class AddMedicalToSuites < ActiveRecord::Migration[5.0]
+  def change
+    add_column :suites, :medical, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302225344) do
+ActiveRecord::Schema.define(version: 20170311014302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,11 +88,12 @@ ActiveRecord::Schema.define(version: 20170302225344) do
 
   create_table "suites", force: :cascade do |t|
     t.integer  "building_id"
-    t.string   "number",                  null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.integer  "size",        default: 0, null: false
+    t.string   "number",                      null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+    t.integer  "size",        default: 0,     null: false
     t.integer  "group_id"
+    t.boolean  "medical",     default: false
     t.index ["building_id"], name: "index_suites_on_building_id", using: :btree
     t.index ["group_id"], name: "index_suites_on_group_id", using: :btree
   end

--- a/spec/features/suites/medical_suite_spec.rb
+++ b/spec/features/suites/medical_suite_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Medical suites' do
+  let(:suite) { FactoryGirl.create(:suite) }
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be toggled from the edit form' do
+    visit edit_suite_path(suite)
+    check 'Medical suite'
+    click_on 'Save'
+    expect(page).to have_css('.suite-medical', text: 'Medical suite')
+  end
+
+  it 'can be done from the suite page' do
+    visit suite_path(suite)
+    click_on 'Make medical suite'
+    expect(page).to have_css('.suite-medical', text: 'Medical suite')
+  end
+end

--- a/spec/helpers/suites_helper_spec.rb
+++ b/spec/helpers/suites_helper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuitesHelper, type: :helper do
+  describe '#medical_val' do
+    it 'returns 1 if not currently a medical suite' do
+      suite = instance_spy('suite', medical: false)
+      expect(helper.medical_val(suite)).to eq(1)
+    end
+    it 'returns 0 if currently a medical suite' do
+      suite = instance_spy('suite', medical: true)
+      expect(helper.medical_val(suite)).to eq(0)
+    end
+  end
+
+  describe '#medical_btn_str' do
+    it 'returns "Make medical suite" if not a medical suite' do
+      suite = instance_spy('suite', medical: false)
+      expect(helper.medical_btn_str(suite)).to eq('Make medical suite')
+    end
+    it 'returns "Make non-medical suite" if a medical suite' do
+      suite = instance_spy('suite', medical: true)
+      expect(helper.medical_btn_str(suite)).to eq('Make non-medical suite')
+    end
+  end
+
+  describe '#medical_str' do
+    it 'returns "Medical suite" if medical is true' do
+      expect(helper.medical_str(true)).to eq('medical suite')
+    end
+    it 'retusn "Non-medical suite" if medical is false' do
+      expect(helper.medical_str(false)).to eq('non-medical suite')
+    end
+  end
+end


### PR DESCRIPTION
Resolves #326
- Add boolean :medical attribute to Suites
- Add hidden form on Suite show to toggle the medical attribute
- Add SuitesHelper with methods to generate the form and describe a given suite

I'm actually liking the pattern for `simple_form_for resource` with hidden fields so we don't need separate routes and service objects for simple changes; obviously it requires validations to live on the model so it doesn't always work, but we may be able to simplify a bit when we refactor.