### PR TITLE
[329] Handle IDR timeouts

### DIFF
--- a/app/controllers/enrollments_controller.rb
+++ b/app/controllers/enrollments_controller.rb
@@ -9,6 +9,9 @@ class EnrollmentsController < ApplicationController
     result = Enrollment.enroll(enrollment_params)
     @enrollment = result[:enrollment]
     handle_action(**result)
+  rescue Rack::Timeout::RequestTimeoutException => exception
+    Honeybadger.notify(exception)
+    handle_idr_timeout
   end
 
   private
@@ -27,5 +30,11 @@ class EnrollmentsController < ApplicationController
     # we can't use the `env` helper because Rails implements a deprecated env
     # method in controllers
     ENV['QUERIER'].constantize
+  end
+
+  def handle_idr_timeout
+    flash[:error] = 'There was a problem with that request, please try again.'
+    @enrollment = Enrollment.new
+    render action: 'new'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,9 @@ class UsersController < ApplicationController
                                querier: querier)
     @user = result[:user]
     handle_action(**result)
+  rescue Rack::Timeout::RequestTimeoutException => exception
+    Honeybadger.notify(exception)
+    handle_idr_timeout
   end
 
   def create
@@ -73,5 +76,11 @@ class UsersController < ApplicationController
     # we can't use the `env` helper because Rails implements a deprecated env
     # method in controllers
     ENV['QUERIER'].constantize
+  end
+
+  def handle_idr_timeout
+    flash[:error] = 'There was a problem with that request, please try again.'
+    @user = User.new
+    render action: 'build'
   end
 end

--- a/spec/features/users/admin_creation_spec.rb
+++ b/spec/features/users/admin_creation_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
+require 'support/fake_profile_querier'
+require 'rack-timeout'
 
 RSpec.feature 'Admin creation' do
   before { log_in FactoryGirl.create(:admin) }
@@ -8,6 +10,23 @@ RSpec.feature 'Admin creation' do
     submit_username('foo@example.com')
     submit_profile_data(first_name: 'John', last_name: 'Smith', role: 'admin')
     expect(page).to have_content('User John Smith created.')
+  end
+
+  context 'with IDR' do
+    before do
+      allow(ENV).to receive(:[]).and_return(nil)
+      allow(ENV).to receive(:[]).with('QUERIER')
+        .and_return('FakeProfileQuerier')
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(FakeProfileQuerier).to receive(:query)
+        .and_raise(Rack::Timeout::RequestTimeoutException.new({}))
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    it 'handles timeout' do
+      visit build_users_path
+      expect { submit_username('foo@example.com') }.not_to raise_error
+    end
   end
 
   def submit_username(username)

--- a/spec/features/users/enrollment_spec.rb
+++ b/spec/features/users/enrollment_spec.rb
@@ -1,17 +1,29 @@
 # frozen_string_literal: true
 require 'rails_helper'
 require 'support/fake_profile_querier'
+require 'rack-timeout'
 
 RSpec.feature 'User enrollment' do
-  before { log_in(FactoryGirl.create(:admin)) }
-
-  it 'can be performed using a list of IDs' do
+  before do
+    log_in(FactoryGirl.create(:admin))
     allow(ENV).to receive(:[]).and_return(nil)
     allow(ENV).to receive(:[]).with('QUERIER').and_return('FakeProfileQuerier')
+  end
+
+  it 'can be performed using a list of IDs' do
     visit new_enrollment_path
     submit_list_of_ids
     expect(page_has_enrollment_results(page)).to be_truthy
   end
+
+  # rubocop:disable RSpec/AnyInstance
+  it 'handles IDR timeout' do
+    allow_any_instance_of(FakeProfileQuerier).to receive(:query)
+      .and_raise(Rack::Timeout::RequestTimeoutException.new({}))
+    visit new_enrollment_path
+    expect { submit_list_of_ids }.not_to raise_error
+  end
+  # rubocop:enable RSpec/AnyInstance
 
   def submit_list_of_ids
     list_of_ids = %w(id1 iD2 id3 ID3 invalidid).join(', ')


### PR DESCRIPTION
Resolves #329
- ~~This currently rescues the exception in UserBuilder, but this might be dangerous as multiple failures during an Enrollment wouldn't be caught (so we might end up with very very long requests that don't exit). See [here](https://github.com/heroku/rack-timeout#errors) for more details (particularly the bullet point for RequestTimeoutException)~~
- Rescues the timeout exception in the controllers to avoid multiple timeouts during enrollment.