### PR TITLE
[353] Allow admins to edit users; reorganize profile pages

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -25,6 +25,10 @@ class UserPolicy < ApplicationPolicy
     new?
   end
 
+  def draw_info?
+    !record.admin? && record.draw_id.present?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,8 @@
 <h1> Editing <%= @user.name %> </h1>
 <%= simple_form_for @user do |f| %>
+  <%= f.input :first_name %>
+  <%= f.input :last_name %>
+  <%= f.input :email %>
   <%= f.input :role, collection: User.roles.keys %>
   <%= f.submit 'Save' %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,11 @@
-<h1> User <%= @user.full_name %> </h1>
-<h2 class="user-role"> <%= @user.role %> </h2>
-<h2 class="user-intent"> <%= @user.intent %> </h2>
+<h2 class="user-name">User <%= @user.full_name %></h2>
+<h3 class="user-role"><%= @user.role %></h3>
+<% if policy(@user).draw_info? %>
+  <h3><%= @user.draw.name %></h3>
+  <h3 class="user-intent"><%= @user.intent %></h3>
+<% end %>
+<% if policy(@user).edit? %>
+  <h3 class="user-email"><%= @user.email %></h3>
+  <p><%= link_to 'Edit', edit_user_path(@user), class: 'button secondary' %></p>
+<% end %>
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -5,9 +5,26 @@ RSpec.feature 'User Editing' do
   let(:user) { FactoryGirl.create(:student) }
   before { log_in FactoryGirl.create(:admin) }
   it 'can update role' do
-    visit edit_user_path(user)
+    visit_edit_form(user)
     select('rep', from: 'user_role')
     click_on 'Save'
     expect(page).to have_css('.user-role', text: 'rep')
+  end
+  it 'can update first name' do
+    visit_edit_form(user)
+    fill_in 'First name', with: 'Captain'
+    click_on 'Save'
+    expect(page).to have_css('.user-name', text: /Captain/)
+  end
+  it 'can update email' do
+    visit_edit_form(user)
+    fill_in 'Email', with: 'foo@foo.com'
+    click_on 'Save'
+    expect(page).to have_css('.user-email', text: 'foo@foo.com')
+  end
+
+  def visit_edit_form(user)
+    visit user_path(user)
+    click_on 'Edit'
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe UserPolicy do
     permissions :index?, :build? do
       it { is_expected.not_to permit(user, User) }
     end
+    permissions :draw_info? do
+      context 'other user is admin' do
+        before { allow(other_user).to receive(:admin?).and_return(true) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'other user is not in draw' do
+        before { allow(other_user).to receive(:draw_id).and_return(nil) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'non-admin in draw' do
+        before do
+          allow(other_user).to receive(:admin?).and_return(false)
+          allow(other_user).to receive(:draw_id).and_return(1)
+        end
+        it { is_expected.to permit(user, other_user) }
+      end
+    end
   end
 
   context 'housing rep' do
@@ -73,6 +90,23 @@ RSpec.describe UserPolicy do
     permissions :index?, :build? do
       it { is_expected.not_to permit(user, User) }
     end
+    permissions :draw_info? do
+      context 'other user is admin' do
+        before { allow(other_user).to receive(:admin?).and_return(true) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'other user is not in draw' do
+        before { allow(other_user).to receive(:draw_id).and_return(nil) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'non-admin in draw' do
+        before do
+          allow(other_user).to receive(:admin?).and_return(false)
+          allow(other_user).to receive(:draw_id).and_return(1)
+        end
+        it { is_expected.to permit(user, other_user) }
+      end
+    end
   end
 
   context 'admin' do
@@ -83,6 +117,23 @@ RSpec.describe UserPolicy do
     end
     permissions :index?, :build? do
       it { is_expected.to permit(user, User) }
+    end
+    permissions :draw_info? do
+      context 'other user is admin' do
+        before { allow(other_user).to receive(:admin?).and_return(true) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'other user is not in draw' do
+        before { allow(other_user).to receive(:draw_id).and_return(nil) }
+        it { is_expected.not_to permit(user, other_user) }
+      end
+      context 'non-admin in draw' do
+        before do
+          allow(other_user).to receive(:admin?).and_return(false)
+          allow(other_user).to receive(:draw_id).and_return(1)
+        end
+        it { is_expected.to permit(user, other_user) }
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #353
- Add profile fields (name / email) back to the user edit form
- Add Edit button to user profiles
- Add draw / e-mail to User profiles and reorganize the view