### PR TITLE
[337] Fix SystemStackError when editing transfer students

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -35,11 +35,11 @@ class Membership < ApplicationRecord
   # MUST come before the status callbacks
   after_save :update_counter_cache
   after_create :increment_counter_cache
-  after_destroy :decrement_counter_cache
+  after_destroy :decrement_counter_cache, if: ->(m) { m.group.present? }
 
   # Group status callbacks
   after_save :update_group_status
-  after_destroy :update_group_status
+  after_destroy :update_group_status, if: ->(m) { m.group.present? }
 
   def readonly?
     if locked_changed? && locked
@@ -53,7 +53,7 @@ class Membership < ApplicationRecord
   private
 
   def user_not_in_group
-    return unless user.group
+    return unless user.group && user.group != group
     errors.add :user, 'already has membership in another group'
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,8 @@ class User < ApplicationRecord
   end
 
   belongs_to :draw
+  has_one :led_group, inverse_of: :leader, dependent: :destroy,
+                      class_name: 'Group'
   has_one :membership, -> { where(status: 'accepted') }, dependent: :destroy
   has_one :group, through: :membership
   has_many :memberships, dependent: :destroy


### PR DESCRIPTION
Resolves #337
- Switch to update_columns in Group#update_status! to avoid callbacks
- Add :led_group association for users with dependent: :destroy to destroy groups led by students if those students are removed from the DB. This happens *before* dependent memberships are destroyed in order to have all the callbacks work and required some reworking of other callbacks to keep tests passing - we should definitely revisit this in the future.