### PR TITLE
[362] Prevent creation of groups with transfer students

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -64,8 +64,10 @@ class DrawlessGroupsController < ApplicationController
   end
 
   def drawless_group_params
-    params.require(:group).permit(:size, :leader_id, :suite, :transfers,
-                                  member_ids: [], remove_ids: [])
+    p = params.require(:group).permit(:size, :leader_id, :suite, :transfers,
+                                      member_ids: [], remove_ids: [])
+    return p if @group
+    p.reject! { |k, _v| k == 'transfers' }
   end
 
   def set_group

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -110,10 +110,12 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:size, :leader_id, :transfers,
-                                  :lottery_number, member_ids: [],
-                                                   remove_ids: [],
-                                                   invitations: [])
+    p = params.require(:group).permit(:size, :leader_id, :transfers,
+                                      :lottery_number, member_ids: [],
+                                                       remove_ids: [],
+                                                       invitations: [])
+    return p if @group
+    p.reject! { |k, _v| k == 'transfers' }
   end
 
   def set_group

--- a/app/views/groups/_form_fields.html.erb
+++ b/app/views/groups/_form_fields.html.erb
@@ -6,7 +6,9 @@
   <% if policy(@group).advanced_edit? %>
     <%= f.input :remove_ids, label: 'Users to remove', collection: @group.removable_members, label_method: :full_name, as: :check_boxes unless @group.removable_members.empty? %>
     <%= f.input :member_ids, label: 'Users to add', label_method: :full_name, as: :check_boxes, collection: @students %>
-    <%= f.input :transfers, label: '# transfer students' %>
+    <% if @group.persisted? %>
+      <%= f.input :transfers, label: '# transfer students' %>
+    <% end %>
   <% end %>
 </div>
 

--- a/spec/features/groups/drawless_group_creation_spec.rb
+++ b/spec/features/groups/drawless_group_creation_spec.rb
@@ -13,6 +13,11 @@ RSpec.feature 'Special housing group creation' do
       expect(page).to have_css('.group-name',
                                text: "#{leader.full_name}'s Group")
     end
+
+    it "doesn't include the transfers field" do
+      visit new_group_path
+      expect(page).not_to have_css('label', text: /\# transfer students/)
+    end
   end
 
   def create_group(size:, leader:, members: [])

--- a/spec/requests/drawless_group_creation_spec.rb
+++ b/spec/requests/drawless_group_creation_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Special group creation', type: :request do
+  let!(:leader) { FactoryGirl.create(:student, intent: 'on_campus') }
+  let(:admin) { FactoryGirl.create(:admin) }
+  before do
+    FactoryGirl.create(:suite_with_rooms, rooms_count: 1)
+    post user_session_path,
+         params: { user: { email: admin.email, password: 'passw0rd' } }
+  end
+  it 'sanitizes the transfers param' do
+    post groups_path,
+         params: { group: { size: 1, leader_id: leader.id, transfers: 1 } }
+    follow_redirect!
+    expect(response.body).not_to include('<h3 class="transfers">')
+  end
+end


### PR DESCRIPTION
Resolves #362
- Remove transfers field from groups form when group is being created
- Sanitize params and remove the `group[transfers]` param unless editing; this is done for both regular and drawless groups
- Add request spec for param sanitization for drawless groups