### PR TITLE
[313] Add ability to unlock group memberships

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -57,6 +57,11 @@ class DrawlessGroupsController < ApplicationController
     handle_action(path: group_path(@group), **result)
   end
 
+  def unlock
+    result = GroupUnlocker.unlock(group: @group)
+    handle_action(path: group_path(@group), **result)
+  end
+
   private
 
   def authorize!

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -98,6 +98,11 @@ class GroupsController < ApplicationController
     handle_action(path: draw_group_path(@draw, @group), **result)
   end
 
+  def unlock
+    result = GroupUnlocker.unlock(group: @group)
+    handle_action(path: draw_group_path(@draw, @group), **result)
+  end
+
   def assign_lottery
     @group.lottery_number = group_params['lottery_number'].to_i
     @color_class = @group.save ? 'success' : 'failure'

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -95,6 +95,13 @@ class Group < ApplicationRecord # rubocop:disable ClassLength
     (members - locked_members).empty? && members_count == size
   end
 
+  # Check if there are any locked memberships
+  #
+  # @return [Boolean] true if there are any unlocked members
+  def unlockable?
+    !locked_members.empty? && suite.nil?
+  end
+
   private
 
   # override default attribute getter to include transfers
@@ -163,7 +170,7 @@ class Group < ApplicationRecord # rubocop:disable ClassLength
     if members_count < size
       self.status = 'open'
     elsif members_count == size
-      self.status = 'full' if open?
+      self.status = 'full' unless finalizing? || lockable?
       self.status = 'locked' if lockable?
     end
   end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -42,7 +42,7 @@ class Membership < ApplicationRecord
   after_destroy :update_group_status, if: ->(m) { m.group.present? }
 
   def readonly?
-    if locked_changed? && locked
+    if locked_changed?
       # we need to allow the membership to be locked
       false
     else
@@ -86,7 +86,7 @@ class Membership < ApplicationRecord
   end
 
   def lockable?
-    return unless locked_changed?
+    return unless locked_changed? && locked
     errors.add :locked, 'must be an accepted membership' unless accepted?
     errors.add :locked, 'must be a finalizing group' unless group.finalizing?
   end

--- a/app/policies/drawless_group_policy.rb
+++ b/app/policies/drawless_group_policy.rb
@@ -2,6 +2,8 @@
 #
 # Policy for permissions on special (non-draw) housing groups
 class DrawlessGroupPolicy < ApplicationPolicy
+  delegate :lock?, :unlock?, to: :group_policy
+
   def select_suite?
     user.admin? && record.locked?
   end
@@ -10,7 +12,9 @@ class DrawlessGroupPolicy < ApplicationPolicy
     record.members.include?(user) || super
   end
 
-  def lock?
-    user.admin? && record.full?
+  private
+
+  def group_policy
+    Pundit.policy!(user, record)
   end
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -68,7 +68,11 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def lock?
-    user.admin? && record.full?
+    user.admin? && !record.open? && !record.locked?
+  end
+
+  def unlock?
+    user.admin? && record.unlockable?
   end
 
   def assign_lottery?

--- a/app/services/group_unlocker.rb
+++ b/app/services/group_unlocker.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+#
+# Service object to unlock groups
+class GroupUnlocker
+  # Initialize a new GroupUnlocker and call #unlock on it
+  def self.unlock(**params)
+    new(**params).unlock
+  end
+
+  # Initialize a GroupLocker
+  #
+  # @param group [Group] The group object to be updated
+  def initialize(group:)
+    @group = group
+    @locked_memberships = group.full_memberships.where(locked: true)
+  end
+
+  # Unlock a group by unlocking each membership
+  #
+  # @return [Hash{Symbol=>Array, Group, Hash}] The result of the finalizing
+  def unlock
+    return error('Group has no locked memberships') unless group.unlockable?
+    ActiveRecord::Base.transaction do
+      locked_memberships.each { |m| m.update!(locked: false) }
+      group.update_status!
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => errors
+    error(error_messages(errors))
+  end
+
+  private
+
+  attr_reader :group, :locked_memberships
+
+  def success
+    { object: [group.draw, group], record: group,
+      msg: { success: "#{group.name} is unlocked." } }
+  end
+
+  def error(errors)
+    { object: [group.draw, group], record: group, msg: { error: errors } }
+  end
+
+  def error_messages(errors)
+    errors.record.errors.full_messages.join(', ')
+  end
+end

--- a/app/views/drawless_groups/show.html.erb
+++ b/app/views/drawless_groups/show.html.erb
@@ -17,7 +17,10 @@
   <br />
   <%= link_to 'Edit', edit_group_path(@group), class: 'button secondary' if policy(@group).edit? %>
   <% if policy(@group).lock? %>
-    <%= link_to 'Lock Group', lock_group_path(@group), method: :put, class: 'button alert' if policy(@group).lock? %>
+    <%= link_to 'Lock Group', lock_group_path(@group), method: :put, class: 'button alert' %>
+  <% end %>
+  <% if policy(@group).unlock? %>
+    <%= link_to 'Unlock All Members', unlock_group_path(@group), method: :put, class: 'button alert' %>
   <% end %>
   <%= link_to('Disband', group_path(@group), method: :delete, class: 'button alert') if policy(@group).destroy? %>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -40,6 +40,7 @@
   <%= link_to 'Invite Members', invite_draw_group_path(@draw, @group), class: 'button secondary' if policy(@group).invite? %>
   <%= link_to 'Accept Invitation', accept_invitation_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).accept_invitation? %>
   <%= link_to 'Lock Group', lock_draw_group_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).lock? %>
+  <%= link_to 'Unlock All Members', unlock_draw_group_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).unlock? %>
   <%= link_to 'Finalize Group', finalize_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize? %>
   <%= link_to 'Finalize Membership', finalize_membership_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize_membership? %>
   <%= link_to('Disband', draw_group_path(@draw, @group), method: :delete, class: 'button alert') if policy(@group).destroy? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
         put 'finalize'
         put 'finalize_membership'
         put 'lock'
+        put 'unlock'
         delete 'leave'
       end
     end
@@ -68,6 +69,7 @@ Rails.application.routes.draw do
   resources :groups, controller: 'drawless_groups' do
     member do
       put 'lock'
+      put 'unlock'
       patch 'select_suite'
     end
   end

--- a/spec/features/groups/group_freezing_spec.rb
+++ b/spec/features/groups/group_freezing_spec.rb
@@ -31,5 +31,13 @@ RSpec.feature 'Group locking' do
       click_on 'Lock Group'
       expect(group.reload).to be_locked
     end
+
+    it 'can be unlocked' do
+      group = FactoryGirl.create(:locked_group)
+      log_in FactoryGirl.create(:admin)
+      visit draw_group_path(group.draw, group)
+      click_on 'Unlock All Members'
+      expect(page).to have_css('.group-status', text: 'Status: Full')
+    end
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -196,4 +196,22 @@ RSpec.describe Group, type: :model do
       expect(group.reload).to be_lockable
     end
   end
+
+  describe '#unlockable?' do
+    it 'returns true when there are _any_ locked members and no suite' do
+      group = FactoryGirl.create(:finalizing_group)
+      group.update!(status: 'full')
+      expect(group.reload).to be_unlockable
+    end
+    it 'returns false if the group has a suite assigned' do
+      group = FactoryGirl.create(:locked_group)
+      allow(group).to receive(:suite)
+        .and_return(instance_spy('suite', nil?: false))
+      expect(group).not_to be_unlockable
+    end
+    it 'returns false if there are no locked members' do
+      group = FactoryGirl.create(:open_group)
+      expect(group).not_to be_unlockable
+    end
+  end
 end

--- a/spec/policies/drawless_group_policy_spec.rb
+++ b/spec/policies/drawless_group_policy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DrawlessGroupPolicy do
     permissions :new?, :create? do
       it { is_expected.not_to permit(user, DrawlessGroup) }
     end
-    permissions :edit?, :update?, :destroy?, :select_suite?, :lock? do
+    permissions :edit?, :update?, :destroy?, :select_suite?, :lock?, :unlock? do
       it { is_expected.not_to permit(user, group) }
     end
     context 'student not in group' do
@@ -33,7 +33,7 @@ RSpec.describe DrawlessGroupPolicy do
     permissions :new?, :create? do
       it { is_expected.not_to permit(user, DrawlessGroup) }
     end
-    permissions :edit?, :update?, :destroy?, :select_suite?, :lock? do
+    permissions :edit?, :update?, :destroy?, :select_suite?, :lock?, :unlock? do
       it { is_expected.not_to permit(user, group) }
     end
     context 'student not in group' do
@@ -59,15 +59,20 @@ RSpec.describe DrawlessGroupPolicy do
     permissions :show?, :edit?, :update?, :destroy? do
       it { is_expected.to permit(user, group) }
     end
-    context 'full group' do
-      before { allow(group).to receive(:full?).and_return(true) }
-      permissions :lock? do
+    permissions :lock? do
+      context 'lockable group' do
+        before do
+          allow(group).to receive(:open?).and_return(false)
+          allow(group).to receive(:locked?).and_return(false)
+        end
         it { is_expected.to permit(user, group) }
       end
-    end
-    context 'not full group' do
-      before { allow(group).to receive(:full?).and_return(false) }
-      permissions :lock? do
+      context 'open group' do
+        before { allow(group).to receive(:open?).and_return(true) }
+        it { is_expected.not_to permit(user, group) }
+      end
+      context 'locked group' do
+        before { allow(group).to receive(:locked?).and_return(true) }
         it { is_expected.not_to permit(user, group) }
       end
     end
@@ -80,6 +85,16 @@ RSpec.describe DrawlessGroupPolicy do
     context 'not locked group' do
       before { allow(group).to receive(:locked?).and_return(false) }
       permissions :select_suite? do
+        it { is_expected.not_to permit(user, group) }
+      end
+    end
+    permissions :unlock? do
+      context 'unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(true) }
+        it { is_expected.to permit(user, group) }
+      end
+      context 'not unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(false) }
         it { is_expected.not_to permit(user, group) }
       end
     end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe GroupPolicy do
       before { allow(group).to receive(:full?).and_return(true) }
       it { is_expected.to permit(user, group) }
     end
-    permissions :lock?, :advanced_edit?, :assign_lottery? do
+    permissions :lock?, :unlock?, :advanced_edit?, :assign_lottery? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -387,7 +387,7 @@ RSpec.describe GroupPolicy do
         it { is_expected.not_to permit(user, group) }
       end
     end
-    permissions :lock?, :advanced_edit? do
+    permissions :lock?, :unlock?, :advanced_edit? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -412,12 +412,29 @@ RSpec.describe GroupPolicy do
       it { is_expected.to permit(user, group) }
     end
     permissions :lock? do
-      context 'full group' do
-        before { allow(group).to receive(:full?).and_return(true) }
+      context 'lockable group' do
+        before do
+          allow(group).to receive(:open?).and_return(false)
+          allow(group).to receive(:locked?).and_return(false)
+        end
         it { is_expected.to permit(user, group) }
       end
-      context 'not full group' do
-        before { allow(group).to receive(:full?).and_return(false) }
+      context 'open group' do
+        before { allow(group).to receive(:open?).and_return(true) }
+        it { is_expected.not_to permit(user, group) }
+      end
+      context 'locked group' do
+        before { allow(group).to receive(:locked?).and_return(true) }
+        it { is_expected.not_to permit(user, group) }
+      end
+    end
+    permissions :unlock? do
+      context 'unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(true) }
+        it { is_expected.to permit(user, group) }
+      end
+      context 'not unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(false) }
         it { is_expected.not_to permit(user, group) }
       end
     end

--- a/spec/services/group_unlocker_spec.rb
+++ b/spec/services/group_unlocker_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GroupUnlocker do
+  describe '.unlock' do
+    xit 'calls #unlock on a new instance'
+  end
+  describe '#unlock' do
+    describe 'success' do
+      let(:group) { FactoryGirl.create(:locked_group) }
+      it 'returns a success flash' do
+        expect(described_class.unlock(group: group)[:msg].keys).to \
+          eq([:success])
+      end
+      it 'updates the group status' do
+        described_class.unlock(group: group)
+        expect(group.reload).not_to be_locked
+      end
+    end
+
+    context 'failure' do
+      let(:group) { FactoryGirl.create(:open_group) }
+      it 'returns an error flash' do
+        expect(described_class.unlock(group: group)[:msg].keys).to eq([:error])
+      end
+      it 'does not change the group status' do
+        old_status = group.status
+        described_class.unlock(group: group)
+        expect(group.reload.status).to eq(old_status)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #313
- Add :unlock routes / actions to groups
- Add GroupUnlocker service object
- Tweak membership validations to permit unlocking of memberships
- Tweak Group#update_status! to revert status from locked
- Update GroupPolicy#lock? to permit the locking of groups in statuses other than full (e.g. finalizing)
- Update GroupUpdater#update to run Group#update_status! after other updates are made
- Delegate :lock? and :unlock? methods in DrawlessGroupPolicy to GroupPolicy to keep things DRY