### PR TITLE
[377] Allow students in draws to create groups

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -10,7 +10,7 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def create?
-    (user.draw && !user.group) || user.admin?
+    student_can_create_group(user) || user.admin?
   end
 
   def edit?
@@ -93,5 +93,9 @@ class GroupPolicy < ApplicationPolicy
 
   def group_can_be_edited_by_leader?(group)
     !group.finalizing? && !group.locked?
+  end
+
+  def student_can_create_group(user)
+    (user.draw && user.draw.pre_lottery? && user.on_campus? && !user.group)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -14,7 +14,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def edit_intent?
-    user.admin? || (user == record && draw_intent_state)
+    user.admin? || (user == record && !user.group && draw_intent_state)
   end
 
   def update_intent?

--- a/app/views/application/_nav_student.html.erb
+++ b/app/views/application/_nav_student.html.erb
@@ -1,16 +1,14 @@
 <ul class="dropdown menu" data-dropdown-menu>
-  <% if current_user.draw && !current_user.draw.draft? %>
-    <% if policy(current_user).edit_intent? %>
-      <li><%= link_to 'Update Housing Intent', edit_intent_user_path(current_user) %></li>
-    <% end %>
+  <% if current_user.draw && policy(current_user.draw).show? %>
     <li><%= link_to 'My Draw', draw_path(current_user.draw) %></li>
-    <% if current_user.group %>
-      <li><%= link_to 'My Group', draw_group_path(current_user.draw, current_user.group) %></li>
-    <% end %>
-  <% else %>
-    <% if current_user.group %>
-      <li><%= link_to 'My Group', group_path(current_user.group) %></li>
-    <% end %>
+  <% end %>
+  <% if policy(current_user).edit_intent? %>
+    <li><%= link_to 'Update Housing Intent', edit_intent_user_path(current_user) %></li>
+  <% end %>
+  <% if current_user.group %>
+    <li><%= link_to 'My Group', draw_group_path(current_user.draw, current_user.group) %></li>
+  <% elsif policy(Group).new? %>
+    <li><%= link_to 'Create Housing Group', new_draw_group_path(current_user.draw) %></li>
   <% end %>
   <!-- eventually add: select a suite / view my suite -->
 </ul>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -69,7 +69,7 @@
   <% if policy(@draw).lottery? %>
     <%= link_to 'Assign lottery numbers', lottery_draw_path(@draw), class: 'button secondary' %>
   <% end %>
-  <% if policy(@draw).update? %>
+  <% if policy(Group).new? %>
     <%= link_to 'Add group to draw', new_draw_group_path(@draw), class: 'button secondary' %>
   <% end %>
   <% if policy(@draw).destroy? %>

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -10,21 +10,42 @@ RSpec.describe GroupPolicy do
     let(:other_group) { FactoryGirl.build_stubbed(:group) }
 
     permissions :create? do
-      context 'in same draw, not in group' do
+      context 'in pre_lottery draw, not in group, on_campus' do
         before do
-          allow(user).to receive(:draw).and_return(instance_spy('Draw'))
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
           allow(user).to receive(:group).and_return(nil)
+          allow(user).to receive(:on_campus?).and_return(true)
         end
         it { is_expected.to permit(user, Group) }
       end
-      context 'in same draw, in group' do
+      context 'in pre_lottery draw, in group, on_campus' do
         before do
-          allow(user).to receive(:draw).and_return(instance_spy('Draw'))
-          allow(user).to receive(:group).and_return(instance_spy('Group'))
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
+          allow(user).to receive(:group).and_return(instance_spy('group'))
+          allow(user).to receive(:on_campus?).and_return(true)
         end
         it { is_expected.not_to permit(user, Group) }
       end
-      context 'not in same draw' do
+      context 'in pre_lottery draw, not in group, not on_campus' do
+        before do
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
+          allow(user).to receive(:group).and_return(nil)
+          allow(user).to receive(:on_campus?).and_return(false)
+        end
+        it { is_expected.not_to permit(user, Group) }
+      end
+      context 'in non-pre_lottery' do
+        before do
+          draw = instance_spy('draw', pre_lottery?: false)
+          allow(user).to receive(:draw).and_return(draw)
+        end
+        it { is_expected.not_to permit(user, Group) }
+      end
+      context 'not in draw' do
+        before { allow(user).to receive(:draw).and_return(nil) }
         it { is_expected.not_to permit(user, Group) }
       end
     end
@@ -179,21 +200,42 @@ RSpec.describe GroupPolicy do
     let(:other_group) { FactoryGirl.build_stubbed(:group) }
 
     permissions :create? do
-      context 'in draw, not in group' do
+      context 'in pre_lottery draw, not in group, on_campus' do
         before do
-          allow(user).to receive(:draw).and_return(instance_spy('Draw'))
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
           allow(user).to receive(:group).and_return(nil)
+          allow(user).to receive(:on_campus?).and_return(true)
         end
         it { is_expected.to permit(user, Group) }
       end
-      context 'in same draw, in group' do
+      context 'in pre_lottery draw, in group, on_campus' do
         before do
-          allow(user).to receive(:draw).and_return(instance_spy('Draw'))
-          allow(user).to receive(:group).and_return(instance_spy('Group'))
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
+          allow(user).to receive(:group).and_return(instance_spy('group'))
+          allow(user).to receive(:on_campus?).and_return(true)
         end
         it { is_expected.not_to permit(user, Group) }
       end
-      context 'not in same draw' do
+      context 'in pre_lottery draw, not in group, not on_campus' do
+        before do
+          draw = instance_spy('draw', pre_lottery?: true)
+          allow(user).to receive(:draw).and_return(draw)
+          allow(user).to receive(:group).and_return(nil)
+          allow(user).to receive(:on_campus?).and_return(false)
+        end
+        it { is_expected.not_to permit(user, Group) }
+      end
+      context 'in non-pre_lottery' do
+        before do
+          draw = instance_spy('draw', pre_lottery?: false)
+          allow(user).to receive(:draw).and_return(draw)
+        end
+        it { is_expected.not_to permit(user, Group) }
+      end
+      context 'not in draw' do
+        before { allow(user).to receive(:draw).and_return(nil) }
         it { is_expected.not_to permit(user, Group) }
       end
     end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -21,7 +21,18 @@ RSpec.describe UserPolicy do
         allow(user).to receive(:draw).and_return(draw)
       end
       permissions :edit_intent?, :update_intent? do
-        it { is_expected.to permit(user, user) }
+        context  'user in group' do # rubocop:disable RSpec/NestedGroups
+          before do
+            allow(user).to receive(:group).and_return(instance_spy('group'))
+          end
+          it { is_expected.not_to permit(user, user) }
+        end
+        context  'user not in group' do # rubocop:disable RSpec/NestedGroups
+          before do
+            allow(user).to receive(:group).and_return(nil)
+          end
+          it { is_expected.to permit(user, user) }
+        end
       end
     end
     context 'draw not pre-lottery status' do
@@ -88,7 +99,18 @@ RSpec.describe UserPolicy do
         allow(user).to receive(:draw).and_return(draw)
       end
       permissions :edit_intent?, :update_intent? do
-        it { is_expected.to permit(user, user) }
+        context 'user in group' do # rubocop:disable RSpec/NestedGroups
+          before do
+            allow(user).to receive(:group).and_return(instance_spy('group'))
+          end
+          it { is_expected.not_to permit(user, user) }
+        end
+        context 'user not in group' do # rubocop:disable RSpec/NestedGroups
+          before do
+            allow(user).to receive(:group).and_return(nil)
+          end
+          it { is_expected.to permit(user, user) }
+        end
       end
     end
     context 'draw not pre-lottery status' do


### PR DESCRIPTION
Resolves #377
- Update GroupPolicy.create? to permit ungrouped, on-campus students in pre_lottery draws to create groups
- Add link to create groups in student nav
- Tweak / improve student nav
- Improve UserPolicy#edit_intent? to prohibit students in groups from changing their intents