### PR TITLE
[349] Allow admins to convert groups to special groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -108,6 +108,11 @@ class GroupsController < ApplicationController
     @color_class = @group.save ? 'success' : 'failure'
   end
 
+  def make_drawless
+    result = GroupDrawRemover.remove(group: @group)
+    handle_action(action: 'show', **result)
+  end
+
   private
 
   def authorize!

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -73,6 +73,13 @@ class Group < ApplicationRecord # rubocop:disable ClassLength
     memberships.where(status: 'invited').map(&:user)
   end
 
+  # Get all of the non-accepted memberships for the group
+  #
+  # @return [Array<Membership>] the memberships that are not accepted
+  def pending_memberships
+    memberships.where.not(status: 'accepted')
+  end
+
   # Get the group's members that can be removed
   #
   # @return[Array<User>] the members of the group with the exception of the

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -87,6 +87,10 @@ class GroupPolicy < ApplicationPolicy
     edit?
   end
 
+  def make_drawless?
+    user.admin?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/services/group_draw_remover.rb
+++ b/app/services/group_draw_remover.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+#
+# Service object to handle the conversion of a regular group to a drawless
+# group. It handles the removal of the draw from all group members and destroys
+# all pending invitations and requests.
+class GroupDrawRemover
+  # permits the calling of :remove on the class
+  def self.remove(**params)
+    new(**params).remove
+  end
+
+  # Initializes a new GroupDrawRemover
+  #
+  # @param group [Group] the group in question
+  def initialize(group:)
+    @group = group
+    @members = group.members
+    @pending = group.pending_memberships
+  end
+
+  # Removes the draw_id from the group and makes other necessary changes
+  #
+  # @return [Hash{Symbol=>Group,Hash,Array}] the results hash
+  def remove
+    ActiveRecord::Base.transaction do
+      group.update!(draw_id: nil)
+      members.each { |s| s.remove_draw.update!(intent: 'on_campus') }
+      pending.each(&:destroy!)
+    end
+    success
+  rescue ActiveRecord::RecordInvalid => errors
+    error(errors)
+  end
+
+  private
+
+  attr_reader :group, :members, :pending
+
+  def success
+    {
+      object: group,
+      msg: { success: "#{group.name} is now a special group" }
+    }
+  end
+
+  def error(errors)
+    {
+      object: [group.draw, group],
+      msg: { error: "Error converting group to a special group: #{errors}" }
+    }
+  end
+end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -43,6 +43,10 @@
   <%= link_to 'Unlock All Members', unlock_draw_group_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).unlock? %>
   <%= link_to 'Finalize Group', finalize_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize? %>
   <%= link_to 'Finalize Membership', finalize_membership_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize_membership? %>
+  <% if policy(@group).make_drawless? %>
+    <%= link_to 'Make special group', make_drawless_draw_group_path(@draw, @group), method: :patch,
+                **with_tooltip(text: 'Remove this group and its members from the draw and convert it to a special group.', class_override: 'button alert') %>
+  <% end %>
   <%= link_to('Disband', draw_group_path(@draw, @group), method: :delete, class: 'button alert') if policy(@group).destroy? %>
 </div>
 <%= link_to 'Return to draw', draw_path(@draw) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
         put 'lock'
         put 'unlock'
         delete 'leave'
+        patch 'make_drawless'
       end
     end
   end

--- a/spec/features/groups/convert_to_drawless_group_spec.rb
+++ b/spec/features/groups/convert_to_drawless_group_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Convert to drawless group' do
+  let(:draw) { FactoryGirl.create(:draw_with_members) }
+  let(:group) { FactoryGirl.create(:full_group, leader: draw.students.first) }
+  before { log_in FactoryGirl.create(:admin) }
+
+  it 'can be performed' do
+    visit draw_group_path(group.draw, group)
+    click_on 'Make special group'
+    expect(page).to have_css('.flash-success',
+                             text: /Group is now a special group/)
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -142,6 +142,20 @@ RSpec.describe Group, type: :model do
     end
   end
 
+  describe '#pending_memberships' do
+    let(:group) { FactoryGirl.create(:open_group) }
+    it 'returns invitations but not accepted memberships' do
+      user = FactoryGirl.create(:student, draw: group.draw, intent: 'on_campus')
+      m = Membership.create(group: group, user: user, status: 'invited')
+      expect(group.pending_memberships).to match([m])
+    end
+    it 'returns requests but not accepted memberships' do
+      user = FactoryGirl.create(:student, draw: group.draw, intent: 'on_campus')
+      m = Membership.create(group: group, user: user, status: 'requested')
+      expect(group.pending_memberships).to match([m])
+    end
+  end
+
   describe '#members' do
     it 'returns only members with an accepted membership' do
       group = FactoryGirl.create(:open_group)

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -188,7 +188,8 @@ RSpec.describe GroupPolicy do
       before { allow(group).to receive(:full?).and_return(true) }
       it { is_expected.to permit(user, group) }
     end
-    permissions :lock?, :unlock?, :advanced_edit?, :assign_lottery? do
+    permissions :lock?, :unlock?, :advanced_edit?, :assign_lottery?,
+                :make_drawless? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -387,7 +388,7 @@ RSpec.describe GroupPolicy do
         it { is_expected.not_to permit(user, group) }
       end
     end
-    permissions :lock?, :unlock?, :advanced_edit? do
+    permissions :lock?, :advanced_edit?, :unlock?, :make_drawless? do
       it { is_expected.not_to permit(user, other_group) }
       it { is_expected.not_to permit(user, group) }
     end
@@ -408,7 +409,7 @@ RSpec.describe GroupPolicy do
     end
     permissions :show?, :edit?, :update?, :destroy?, :accept_request?,
                 :send_invites?, :advanced_edit?, :view_pending_members?,
-                :reject_pending?, :change_leader? do
+                :reject_pending?, :change_leader?, :make_drawless? do
       it { is_expected.to permit(user, group) }
     end
     permissions :lock? do

--- a/spec/services/group_draw_remover_spec.rb
+++ b/spec/services/group_draw_remover_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GroupDrawRemover do
+  describe '.remove' do
+    xit 'calls :remove on an instance of GroupDrawRemover'
+  end
+
+  describe '#remove' do
+    context 'success' do
+      let(:member) { instance_spy('user', draw_id: 123) }
+      let(:group) { instance_spy('group', draw_id: 123) }
+      let(:membership) { instance_spy('membership') }
+      let(:invitation) { instance_spy('membership') }
+      before do
+        allow(group).to receive(:members).and_return([member])
+        allow(group).to receive(:pending_memberships).and_return([invitation])
+      end
+      it 'removes the draw_id from the group' do
+        described_class.remove(group: group)
+        expect(group).to have_received(:update!).with(draw_id: nil)
+      end
+      it 'removes the draw_id from members and saves old_draw_id' do
+        described_class.remove(group: group)
+        expect(member).to have_received(:remove_draw)
+      end
+      it 'destroys invitations' do
+        described_class.remove(group: group)
+        expect(invitation).to have_received(:destroy!)
+      end
+      it 'sets the :object to the group' do
+        result = described_class.remove(group: group)
+        expect(result[:object]).to eq(group)
+      end
+      it 'sets a success message' do
+        result = described_class.remove(group: group)
+        expect(result[:msg].keys).to match([:success])
+      end
+    end
+
+    context 'failure' do
+      let(:draw) { instance_spy('draw') }
+      let(:group) { instance_spy('group', draw: draw) }
+      before do
+        allow(group).to receive(:update!)
+          .and_raise(ActiveRecord::RecordInvalid)
+      end
+      it 'sets the :object to the draw and group' do
+        result = described_class.remove(group: group)
+        expect(result[:object]).to match([draw, group])
+      end
+      it 'sets a success message' do
+        result = described_class.remove(group: group)
+        expect(result[:msg].keys).to match([:error])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #349
- Add GroupDrawRemover service object; handles to removal of the draw_id parameter from groups and members and destroys pending memberships
- Add Group#pending_memberships