### PR TITLE
[357] Add housing results

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -166,6 +166,10 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
     handle_action(**result)
   end
 
+  def results
+    @suites_with_results = SuitesWithRoomsAssignedQuery.new(@draw.suites).call
+  end
+
   private
 
   def authorize!

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+#
+# Controller for housing results
+class ResultsController < ApplicationController
+  def suites
+    @suites = SuitesWithRoomsAssignedQuery.call
+  end
+
+  def students
+    @students = User.includes(:room).where(role: %w(student rep))
+                    .where.not(room_id: nil).order(:last_name)
+  end
+
+  private
+
+  def authorize!
+    authorize :results, :show?
+  end
+end

--- a/app/helpers/draws_helper.rb
+++ b/app/helpers/draws_helper.rb
@@ -63,7 +63,7 @@ module DrawsHelper
   #
   # @return [String] in format "March 21, 2:00 pm"
   def format_email_date(date)
-    date.strftime('%B %e,%l:%M %P')
+    date.strftime('%B %e, %l:%M %P')
   end
 
   private

--- a/app/helpers/results_helper.rb
+++ b/app/helpers/results_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+#
+# Helper module for results
+module ResultsHelper
+  # Return a string describing the occupants of a room
+  #
+  # @param room [Room] the room in question
+  # @return [String] the occupant description
+  def room_occupants(room)
+    students = room.users
+    transfers = room.beds - students.count
+    [students_str(students), transfers_str(transfers)].compact.join(', ')
+  end
+
+  private
+
+  def students_str(students)
+    students.map(&:full_name).join(', ') unless students.empty?
+  end
+
+  def transfers_str(transfers)
+    pluralize(transfers, 'transfer') unless transfers.zero?
+  end
+end

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -112,6 +112,10 @@ class DrawPolicy < ApplicationPolicy
     select_suites?
   end
 
+  def results?
+    (user.admin? || user.rep?) && record.results?
+  end
+
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/policies/drawless_group_policy.rb
+++ b/app/policies/drawless_group_policy.rb
@@ -15,6 +15,6 @@ class DrawlessGroupPolicy < ApplicationPolicy
   private
 
   def group_policy
-    Pundit.policy!(user, record)
+    Pundit.policy!(user, Group.find(record.id))
   end
 end

--- a/app/policies/results_policy.rb
+++ b/app/policies/results_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+#
+# Policy for results
+# rubocop:disable StructInheritance
+class ResultsPolicy < Struct.new(:user, :results)
+  def show?
+    user.admin?
+  end
+end

--- a/app/queries/suites_with_rooms_assigned_query.rb
+++ b/app/queries/suites_with_rooms_assigned_query.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+#
+# Query object to return all suites that have rooms assigned
+class SuitesWithRoomsAssignedQuery
+  # See IntentMetricsQuery for explanation.
+  class << self
+    delegate :call, to: :new
+  end
+
+  # Initialize a SuitesWithRoomsAssignedQuery instance
+  #
+  # @param relation [Suite::ActiveRecord_Relation] base relation to use for the
+  #   query object, defaults to all suites
+  def initialize(relation = Suite.all)
+    @relation = relation
+  end
+
+  # Execute the query
+  #
+  # @return [Suite::ActiveRecord_Relation] the suites for which rooms have been
+  #   assigned, eager loads rooms and users
+  def call
+    @relation.includes(rooms: :users).where.not(users: { room_id: nil })
+             .order(:number)
+  end
+end

--- a/app/views/application/_nav_admin.html.erb
+++ b/app/views/application/_nav_admin.html.erb
@@ -28,5 +28,12 @@
       <li><%= link_to 'New Building', new_building_path %></li>
     </ul>
   </li>
+  <li>
+    <a href="#">Results</a>
+    <ul class="menu vertical">
+      <li><%= link_to 'Results by students', students_results_path %></li>
+      <li><%= link_to 'Results by suites', suites_results_path %></li>
+    </ul>
+  </li>
   <li><%= link_to 'Settings', settings_path(@current_college) %></li>
 </ul>

--- a/app/views/draws/results.html.erb
+++ b/app/views/draws/results.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @draw.name %> - Results</h1>
+<%= render 'results/suites_table', suites: @suites_with_results %>
+<%= link_to 'Back to draw', draw_path(@draw) %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -14,7 +14,7 @@
 <% if policy(@draw).group_report? %>
   <div class="group-report">
     <h3>Group Report</h3>
-    <% if @draw.lottery? || @draw.suite_selection?# || draw.results? %>
+    <% if @draw.lottery? || @draw.suite_selection? || @draw.results? %>
       <%= render 'groups/secondary_report', groups: @groups_by_size, path: draw_path(@draw),
                                             actions_partial: 'groups/actions' %>
     <% else %>
@@ -111,6 +111,9 @@
   <% end %>
   <% if policy(@draw).select_suites? %>
     <%= link_to 'Select suites', select_suites_draw_path(@draw), class: 'button' %>
+  <% end %>
+  <% if policy(@draw).results? %>
+    <%= link_to 'View results', results_draw_path(@draw), class: 'button' %>
   <% end %>
   <% if policy(Group).new? && policy(@draw).group_actions? %>
     <%= link_to 'Add group to draw', new_draw_group_path(@draw), class: 'button secondary' %>

--- a/app/views/results/_suites_table.html.erb
+++ b/app/views/results/_suites_table.html.erb
@@ -1,0 +1,25 @@
+<% if suites.empty? %>
+  <p>No results yet - students must have rooms assigned before we can display results.</p>
+<% else %>
+<table>
+  <thead>
+    <tr>
+      <td>Suite</td>
+      <td>Room</td>
+      <td>Occupents</td>
+    </tr>
+  </thead>
+  <tbody>
+    <% suites.each do |suite| %>
+      <% suite.rooms.order(:number).each do |room| %>
+        <% next if room.beds.zero? %>
+        <tr class="result-room-<%= room.id %>">
+          <td><%= suite.number %></td>
+          <td><%= room.number %></td>
+          <td class="student"><%= room_occupants(room) %></td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<% end %>

--- a/app/views/results/students.html.erb
+++ b/app/views/results/students.html.erb
@@ -1,0 +1,21 @@
+<h1>Results by student</h1>
+<% if @students.empty? %>
+  <p>No results yet - students must have rooms assigned before we can display results.</p>
+<% else %>
+  <table>
+    <thead>
+      <tr>
+        <td>Student</td>
+        <td>Room</td>
+      </tr>
+    </thead>
+    <tbody>
+      <% @students.each do |student| %>
+        <tr class="result-student-<%= student.id %>">
+          <td><%= student.full_name %></td>
+          <td class="room"><%= student.room.number %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/results/suites.html.erb
+++ b/app/views/results/suites.html.erb
@@ -1,0 +1,2 @@
+<h1>Results by suite</h1>
+<%= render 'suites_table', suites: @suites %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       patch 'start_selection'
       get 'select_suites'
       patch 'assign_suites'
+      get 'results'
     end
 
     resources :groups do
@@ -91,4 +92,11 @@ Rails.application.routes.draw do
   end
 
   resource :email_export, only: %i(new create)
+
+  resources :results, only: [] do
+    collection do
+      get 'students'
+      get 'suites'
+    end
+  end
 end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature 'Results' do
+  let!(:data) { create_data }
+  before do
+    create_data
+    log_in FactoryGirl.create(:admin)
+  end
+
+  it 'can be listed by student' do
+    visit root_path
+    click_on 'Results by student'
+    expect(page_has_student_results(page)).to be_truthy
+  end
+
+  it 'can be listed by suite' do
+    visit root_path
+    click_on 'Results by suite'
+    expect(page_has_room_results(page)).to be_truthy
+  end
+
+  it 'can be viewed for specific draws' do
+    visit draw_path(Draw.first) # this sucks
+    click_on 'View results'
+    expect(page_has_room_results(page)).to be_truthy
+  end
+
+  def page_has_student_results(page)
+    data[:members].all? do |member|
+      page.assert_selector("tr.result-student-#{member.id} td.room",
+                           text: member.room.number)
+    end
+  end
+
+  def page_has_room_results(page)
+    data[:rooms].all? do |room|
+      if !room.users.empty?
+        page.assert_selector("tr.result-room-#{room.id} td.student",
+                             text: room.users.first.full_name)
+      else
+        page.assert_selector("tr.result-room-#{room.id} td.student",
+                             text: '1 transfer')
+      end
+    end
+  end
+
+  def create_data # rubocop:disable MethodLength, AbcSize
+    draw = FactoryGirl.create(:draw_with_members, students_count: 2,
+                                                  status: 'suite_selection')
+    transfer = FactoryGirl.create(:open_group, leader: draw.students.last,
+                                               transfers: 1)
+    special = FactoryGirl.create(:drawless_group, size: 2)
+    group = FactoryGirl.create(:locked_group, leader: draw.students.first)
+    suite1 = FactoryGirl.create(:suite_with_rooms,
+                                rooms_count: special.size, group: special,
+                                draws: [draw])
+    suite2 = FactoryGirl.create(:suite_with_rooms,
+                                rooms_count: group.size, group: group,
+                                draws: [draw])
+    suite3 = FactoryGirl.create(:suite_with_rooms,
+                                rooms_count: transfer.size, group: transfer,
+                                draws: [draw])
+    assign_students_to_rooms(special => suite1, group => suite2,
+                             transfer => suite3)
+    members = special.members + group.members + transfer.members
+    rooms = suite1.rooms + suite2.rooms + suite3.rooms
+    draw.update!(status: 'results')
+    { members: members, rooms: rooms }
+  end
+
+  def assign_students_to_rooms(assignment_hash)
+    assignment_hash.each do |group, suite|
+      group.members.each_with_index do |member, i|
+        member.update(room_id: suite.rooms[i].id)
+      end
+    end
+  end
+end

--- a/spec/helpers/draws_helper_spec.rb
+++ b/spec/helpers/draws_helper_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe DrawsHelper, type: :helper do
 
   describe '#format_email_date' do
     it 'returns the appropriate format' do
-      expected = 'March 21, 2:00 pm'
       date = DateTime.new(2017, 3, 21, 14, 0o0).in_time_zone
+      expected = date.strftime('%B %e, %l:%M %P')
       expect(helper.format_email_date(date)).to eq(expected)
     end
   end

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ResultsHelper, type: :helper do
+  describe '#room_occupants' do
+    let(:occupants) { [instance_spy('user', full_name: 'John Doe')] }
+    let(:room) { instance_spy('room', users: occupants) }
+
+    it 'returns only student names if no transfers' do
+      allow(room).to receive(:beds).and_return(1)
+      expect(helper.room_occupants(room)).to eq('John Doe')
+    end
+    it 'returns only transfers pluralized if no students' do
+      allow(room).to receive(:users).and_return([])
+      allow(room).to receive(:beds).and_return(2)
+      expect(helper.room_occupants(room)).to eq('2 transfers')
+    end
+    it 'returns the combined string when appropriate' do
+      allow(room).to receive(:students)
+        .and_return([FactoryGirl.build(:student)])
+      allow(room).to receive(:beds).and_return(2)
+      expect(helper.room_occupants(room)).to eq('John Doe, 1 transfer')
+    end
+  end
+end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DrawPolicy do
                 :oversubscription?, :toggle_size_lock?, :start_lottery?,
                 :lottery_confirmation?, :start_selection?, :bulk_on_campus?,
                 :select_suites?, :assign_suites?, :reminder?, :intent_reminder?,
-                :locking_reminder?, :lock_all_sizes? do
+                :locking_reminder?, :lock_all_sizes?, :results? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
@@ -179,6 +179,17 @@ RSpec.describe DrawPolicy do
           allow(draw).to receive(:intent_deadline)
             .and_return(Time.zone.yesterday)
         end
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
+
+    permissions :results? do
+      context 'draw is in results phase' do
+        before { allow(draw).to receive(:results?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+      context 'draw is not in results phase' do
+        before { allow(draw).to receive(:results?).and_return(false) }
         it { is_expected.not_to permit(user, draw) }
       end
     end
@@ -387,6 +398,17 @@ RSpec.describe DrawPolicy do
           allow(draw).to receive(:intent_deadline)
             .and_return(Time.zone.yesterday)
         end
+        it { is_expected.not_to permit(user, draw) }
+      end
+    end
+
+    permissions :results? do
+      context 'draw is in results phase' do
+        before { allow(draw).to receive(:results?).and_return(true) }
+        it { is_expected.to permit(user, draw) }
+      end
+      context 'draw is not in results phase' do
+        before { allow(draw).to receive(:results?).and_return(false) }
         it { is_expected.not_to permit(user, draw) }
       end
     end

--- a/spec/policies/drawless_group_policy_spec.rb
+++ b/spec/policies/drawless_group_policy_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe DrawlessGroupPolicy do
   context 'student' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
     let(:group) { FactoryGirl.build_stubbed(:drawless_group) }
+    before { allow(Group).to receive(:find).and_return(group) }
+
     permissions :new?, :create? do
       it { is_expected.not_to permit(user, DrawlessGroup) }
     end
@@ -30,6 +32,8 @@ RSpec.describe DrawlessGroupPolicy do
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
     let(:group) { FactoryGirl.build_stubbed(:drawless_group) }
+    before { allow(Group).to receive(:find).and_return(group) }
+
     permissions :new?, :create? do
       it { is_expected.not_to permit(user, DrawlessGroup) }
     end
@@ -53,6 +57,8 @@ RSpec.describe DrawlessGroupPolicy do
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     let(:group) { FactoryGirl.build_stubbed(:drawless_group) }
+    before { allow(Group).to receive(:find).and_return(group) }
+
     permissions :new?, :create? do
       it { is_expected.to permit(user, DrawlessGroup) }
     end

--- a/spec/policies/results_policy_spec.rb
+++ b/spec/policies/results_policy_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ResultsPolicy do
+  subject { described_class }
+  let(:admin) { instance_spy('user', admin?: true) }
+  let(:non_admin) { instance_spy('user', admin?: false) }
+
+  permissions :show? do
+    it { is_expected.to permit(admin, :results) }
+    it { is_expected.not_to permit(non_admin, :results) }
+  end
+end

--- a/spec/queries/suites_with_rooms_assigned_query_spec.rb
+++ b/spec/queries/suites_with_rooms_assigned_query_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SuitesWithRoomsAssignedQuery do
+  it 'returns all suites with rooms assigned' do
+    assigned = create_suite_with_rooms_assigned
+    _unassigned = FactoryGirl.create(:suite_with_rooms)
+    expect(described_class.call).to match_array([assigned])
+  end
+
+  it 'can be scoped' do
+    expected = create_suite_with_rooms_assigned(size: 1)
+    _unexpected = create_suite_with_rooms_assigned(size: 2)
+    result = described_class.new(Suite.where(size: 1)).call
+    expect(result).to match_array([expected])
+  end
+
+  it 'orders results by suite number' do
+    second = create_suite_with_rooms_assigned(number: '21')
+    first = create_suite_with_rooms_assigned(number: '12')
+    expect(described_class.call).to match_array([first, second])
+  end
+
+  # rubocop:disable MethodLength
+  def create_suite_with_rooms_assigned(size: 1, number: nil)
+    base_suite_hash = { rooms_count: size }
+    suite_hash = if number
+                   base_suite_hash.merge(number: number)
+                 else
+                   base_suite_hash
+                 end
+    suite = FactoryGirl.create(:suite_with_rooms, **suite_hash)
+    group = FactoryGirl.create(:drawless_group, size: size)
+    suite.update!(group_id: group.id)
+    group.members.each_with_index do |student, i|
+      student.update!(room_id: suite.rooms[i].id)
+    end
+    suite
+  end
+  # rubocop:enable MethodLength
+end


### PR DESCRIPTION
Resolves #357
- Add Results routes, organized by student and by suite
- Add ResultsHelper
- Fix broken special group locking (policy issue)

Blocked on #211, will block #358