### PR TITLE
[148] Ensure membership errors display correctly

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -25,7 +25,7 @@ class DrawlessGroupsController < ApplicationController
     result = DrawlessGroupCreator.new(drawless_group_params).create!
     @group = result[:record]
     set_form_data unless result[:object]
-    handle_action(path: new_group_path, **result)
+    handle_action(action: 'new', **result)
   end
 
   def edit; end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,9 +20,9 @@ class GroupsController < ApplicationController
     p = group_params.to_h
     p[:leader_id] = current_user.id unless current_user.admin?
     result = GroupCreator.new(p).create!
-    @group = result[:group]
+    @group = result[:record]
     set_form_data unless result[:object]
-    handle_action(path: new_draw_group_path(@draw), **result)
+    handle_action(action: 'new', **result)
   end
 
   def edit; end
@@ -31,7 +31,7 @@ class GroupsController < ApplicationController
     result = GroupUpdater.new(group: @group, params: group_params).update
     @group = result[:record]
     set_form_data unless result[:object]
-    handle_action(path: edit_draw_group_path(@draw, @group), **result)
+    handle_action(action: 'edit', **result)
   end
 
   def destroy
@@ -159,6 +159,7 @@ class GroupsController < ApplicationController
 
   def set_form_data
     @group ||= Group.new(draw: @draw)
+    @group.members.delete_all unless @group.persisted?
     @students = UngroupedStudentsQuery.new(@draw.students.on_campus).call
     @leader_students = @group.members.empty? ? @students : @group.members
     @suite_sizes = @draw.open_suite_sizes

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -38,12 +38,10 @@ class Group < ApplicationRecord # rubocop:disable ClassLength
   validate :validate_status, if: ->(g) { g.size.present? }
 
   before_validation :add_leader_to_members, if: ->(g) { g.leader.present? }
+  after_save :update_status!, if: ->(g) { g.transfers_changed? }
   before_destroy :remove_member_rooms
-
   after_destroy :restore_member_draws, if: ->(g) { g.draw.nil? }
   after_destroy :notify_members_of_disband
-
-  after_save :update_status!, if: ->(g) { g.transfers_changed? }
 
   attr_reader :remove_ids
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -57,7 +57,7 @@ class Membership < ApplicationRecord
 
   def user_not_in_group
     return unless user.group && user.group != group
-    errors.add :user, 'already has membership in another group'
+    errors.add :base, "#{user.full_name} already belongs to another group"
   end
 
   def update_group_status
@@ -76,16 +76,17 @@ class Membership < ApplicationRecord
 
   def matching_draw
     return if user.draw == group.draw
-    errors.add :user, 'must belong to same draw as group'
+    errors.add :base, "#{user.full_name} is not in the same draw as the group"
   end
 
   def group_is_open
+    return unless !persisted? || status_changed?
     errors.add :group, 'must be open' unless group.open?
   end
 
   def user_on_campus
     return if user.on_campus?
-    errors.add :user, 'must be living on campus to join a group'
+    errors.add :base, "#{user.full_name} is not living on campus"
   end
 
   def lockable?

--- a/app/services/creators/creator.rb
+++ b/app/services/creators/creator.rb
@@ -23,29 +23,31 @@ class Creator
   #   A results hash with a message to set in the flash and either `nil`
   #   or the created object.
   def create!
-    obj = klass.send(:new, **params)
+    @obj = klass.send(:new, **params)
     if obj.save
-      success(obj)
+      success
     else
-      error(obj)
+      error
     end
+  rescue ActiveRecord::RecordInvalid => e
+    error(e.record)
   end
 
   private
 
-  attr_reader :klass, :params, :name_method
+  attr_reader :klass, :params, :name_method, :obj
 
-  def success(obj)
+  def success
     {
       object: obj, record: obj,
       msg: { success: "#{obj.send(name_method)} created." }
     }
   end
 
-  def error(obj)
-    errors = obj.errors.full_messages
+  def error(object = obj)
+    errors = object.errors.full_messages
     {
-      object: nil, record: obj,
+      object: nil, record: object,
       msg: { error: "Please review the errors below:\n#{errors.join("\n")}" }
     }
   end

--- a/app/services/creators/drawless_group_creator.rb
+++ b/app/services/creators/drawless_group_creator.rb
@@ -19,15 +19,15 @@ class DrawlessGroupCreator < Creator
   # @return [Hash{Symbol=>Group,Hash}] a results hash with a message to set in
   #   flash an either `nil` or the created group.
   def create!
-    group = ActiveRecord::Base.transaction do
+    @obj = ActiveRecord::Base.transaction do
       ensure_valid_members
       group = Group.new(**params)
       group.save!
       group
     end
-    success(group)
-  rescue ActiveRecord::RecordInvalid
-    error(group)
+    success
+  rescue ActiveRecord::RecordInvalid => e
+    error(e.record)
   end
 
   private

--- a/app/services/creators/group_creator.rb
+++ b/app/services/creators/group_creator.rb
@@ -31,8 +31,21 @@ class GroupCreator < Creator
     @params.delete(:remove_ids)
   end
 
-  def success(group)
-    { object: [group.draw, group], group: group,
-      msg: { success: "#{group.name} created." } }
+  def success
+    {
+      object: [obj.draw, obj], group: obj,
+      msg: { success: "#{obj.name} created." }
+    }
+  end
+
+  def error(object = @obj)
+    errors = object.errors.full_messages
+    {
+      object: nil, record: object,
+      msg: {
+        error: "There was a problem creating the group: #{errors.join(', ')}. "\
+        'Please make sure you are not adding too many students.'
+      }
+    }
   end
 end

--- a/app/services/creators/membership_creator.rb
+++ b/app/services/creators/membership_creator.rb
@@ -19,16 +19,16 @@ class MembershipCreator < Creator
 
   private
 
-  def success(membership)
-    { object: [membership.group.draw, membership.group], membership: membership,
-      msg: { success: "Membership in #{membership.group.name} created for "\
-        "#{membership.user.name}." } }
+  def success
+    { object: [obj.group.draw, obj.group], membership: obj,
+      msg: { success: "Membership in #{obj.group.name} created for "\
+        "#{obj.user.name}." } }
   end
 
-  def error(membership)
-    errors = membership.errors.full_messages
+  def error
+    errors = obj.errors.full_messages
     {
-      object: nil, membership: membership,
+      object: nil, membership: obj,
       msg: { error: "Please review the errors below:\n#{errors.join("\n")}" },
       errors: errors,
       params: params

--- a/app/services/group_draw_remover.rb
+++ b/app/services/group_draw_remover.rb
@@ -28,8 +28,8 @@ class GroupDrawRemover
       pending.each(&:destroy!)
     end
     success
-  rescue ActiveRecord::RecordInvalid => errors
-    error(errors)
+  rescue ActiveRecord::ActiveRecordError => e
+    error(e)
   end
 
   private

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
         after(:create) do |g|
           g.draw.update(status: 'pre_lottery')
           g.update(status: 'finalizing')
-          g.full_memberships.each { |m| m.update(locked: true) }
+          g.full_memberships.each { |m| m.update!(locked: true) }
           g.update(status: 'locked')
         end
       end


### PR DESCRIPTION
Resolves #148
- Check membership validity before validating a group
- Change create / update actions to rendering responses instead of
  redirecting for groups
- Fix bug in GroupsController#create that prevented group errors from
  being displayed after invalid submission
- Tweak group creator to properly handle invalid params
- Fix all the ensuing bugs :-\