### PR TITLE
[316 / several] Add group and membership related emails

### DIFF
--- a/app/mailers/student_mailer.rb
+++ b/app/mailers/student_mailer.rb
@@ -8,10 +8,10 @@ class StudentMailer < ApplicationMailer
   #
   # @param user [User] the user to send the invitation to
   # @param college [College] the college to pull settings from
-  def draw_invitation(user, college)
+  def draw_invitation(user:, college: nil)
+    determine_college(college)
     @user = user
     @intent_deadline = user.draw.intent_deadline
-    @college = college
     mail(to: @user.email, subject: 'The housing process has begun')
   end
 
@@ -19,9 +19,72 @@ class StudentMailer < ApplicationMailer
   #
   # @param user [User] the group leader to send the invitation to
   # @param college [College] the college to pull settings from
-  def selection_invite(user, college)
+  def selection_invite(user:, college: nil)
+    determine_college(college)
     @user = user
-    @college = college
     mail(to: @user.email, subject: 'Time to select a suite!')
+  end
+
+  # Send notification to a user that their group was deleted
+  #
+  # @param user [User] the group leader to send the notification to
+  # @param college [College] the college to pull settings from
+  def disband_notification(user:, college: nil)
+    determine_college(college)
+    @user = user
+    mail(to: @user.email, subject: 'Your housing group has been disbanded')
+  end
+
+  # Send notification to a user that their group is finalizing
+  #
+  # @param user [User] the group leader to send the notification to
+  # @param college [College] the college to pull settings from
+  def finalizing_notification(user:, college: nil)
+    determine_college(college)
+    @user = user
+    @finalizing_path = if user.group.draw
+                         draw_groups_url(user.group)
+                       else
+                         groups_url(user.group)
+                       end
+    mail(to: @user.email, subject: 'Confirm your housing group')
+  end
+
+  # Send notification to a leader that a user joined their group
+  #
+  # @param user [User] the group leader to send the notification to
+  # @param college [College] the college to pull settings from
+  def joined_group(joined:, group:, college: nil)
+    determine_college(college)
+    @user = group.leader
+    @joined = joined
+    mail(to: @user.email, subject: "#{joined.full_name} has joined your group")
+  end
+
+  # Send notification to a leader that a user left their group
+  #
+  # @param user [User] the group leader to send the notification to
+  # @param college [College] the college to pull settings from
+  def left_group(left:, group:, college: nil)
+    determine_college(college)
+    @user = group.leader
+    @left = left
+    mail(to: @user.email, subject: "#{left.full_name} has left your group")
+  end
+
+  # Send notification to a user that their group is locked
+  #
+  # @param user [User] the group leader to send the notification to
+  # @param college [College] the college to pull settings from
+  def group_locked(user:, college: nil)
+    determine_college(college)
+    @user = user
+    mail(to: @user.email, subject: 'Your housing group is now locked')
+  end
+
+  private
+
+  def determine_college(college)
+    @college = college || College.first || College.new
   end
 end

--- a/app/models/draw.rb
+++ b/app/models/draw.rb
@@ -173,9 +173,8 @@ class Draw < ApplicationRecord
   #
   # @param [Mailer] The mailer to use
   def notify_next_groups(mailer = StudentMailer)
-    college = College.first
     next_groups.each do |group|
-      mailer.selection_invite(group.leader, college).deliver_later
+      mailer.selection_invite(user: group.leader).deliver_later
     end
   end
 

--- a/app/services/draw_activator.rb
+++ b/app/services/draw_activator.rb
@@ -59,7 +59,7 @@ class DrawActivator
 
   def send_emails
     draw.students.each do |student|
-      mailer.draw_invitation(student, college).deliver_later
+      mailer.draw_invitation(user: student, college: college).deliver_later
     end
   end
 

--- a/app/services/group_finalizer.rb
+++ b/app/services/group_finalizer.rb
@@ -26,6 +26,7 @@ class GroupFinalizer
         group.leader.membership.update!(locked: true)
       end
     end
+    notify_members
     success
   rescue ActiveRecord::RecordInvalid => failures
     @errors = failures
@@ -61,5 +62,12 @@ class GroupFinalizer
   def success
     { object: [group.draw, group], record: group,
       msg: { success: "#{group.name} is being finalized." } }
+  end
+
+  def notify_members
+    members = group.members - [group.leader]
+    members.each do |m|
+      StudentMailer.finalizing_notification(user: m).deliver_later
+    end
   end
 end

--- a/app/views/student_mailer/disband_notification.html.erb
+++ b/app/views/student_mailer/disband_notification.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p>Your housing group has been disbanded, either by your leader or an admin.
+    Please e-mail <%= @college.admin_email %> if you have any questions.</p>
+    <p>Sincerely,<br /><%= @college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/disband_notification.text.erb
+++ b/app/views/student_mailer/disband_notification.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @user.name %>,
+Your housing group has been disbanded, either by your leader or an admin.
+Please e-mail <%= @college.admin_email %> if you have any questions.
+Sincerely,
+<%= @college.dean %>

--- a/app/views/student_mailer/finalizing_notification.html.erb
+++ b/app/views/student_mailer/finalizing_notification.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p>Your group is now in the process of being confirmed. Please go to <%= "#{@college.site_url}#{@finalizing_path}" %> to confirm your membership.</p>
+    <p>Please e-mail <%= @college.admin_email %> if you have any questions.</p>
+    <p>Sincerely,<br /><%= @college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/finalizing_notification.text.erb
+++ b/app/views/student_mailer/finalizing_notification.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @user.name %>,
+Your group is now in the process of being confirmed. Please go to <%= "#{@college.site_url}#{@finalizing_path}" %> to confirm your membership.
+Please e-mail <%= @college.admin_email %> if you have any questions.
+Sincerely,
+<%= @college.dean %>

--- a/app/views/student_mailer/group_locked.html.erb
+++ b/app/views/student_mailer/group_locked.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p>Your housing group is now locked. Please e-mail <%= @college.admin_email %> if you need to make any changes.</p>
+    <p>Sincerely,<br /><%= @college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/group_locked.text.erb
+++ b/app/views/student_mailer/group_locked.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @user.name %>,
+Your housing group is now locked.
+Please e-mail <%= @college.admin_email %> if you need to make any changes.
+Sincerely,
+<%= @college.dean %>

--- a/app/views/student_mailer/joined_group.html.erb
+++ b/app/views/student_mailer/joined_group.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p><%= @joined.full_name %> has joined your housing group! %></p>
+    <p>Sincerely,<br /><%= @college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/joined_group.text.erb
+++ b/app/views/student_mailer/joined_group.text.erb
@@ -1,0 +1,4 @@
+Hi <%= @user.name %>,
+<%= @joined.full_name %> has joined your housing group! %>
+Sincerely,
+<%= @college.dean %>

--- a/app/views/student_mailer/left_group.html.erb
+++ b/app/views/student_mailer/left_group.html.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi <%= @user.name %>,</p>
+    <p><%= @left.full_name %> has left your housing group.</p>
+    <p>Sincerely,<br /><%= @college.dean %></p>
+  </body>
+</html>

--- a/app/views/student_mailer/left_group.text.erb
+++ b/app/views/student_mailer/left_group.text.erb
@@ -1,0 +1,4 @@
+Hi <%= @user.name %>,
+<%= @left.full_name %> has left your housing group.
+Sincerely,
+<%= @college.dean %>

--- a/spec/models/draw_spec.rb
+++ b/spec/models/draw_spec.rb
@@ -282,9 +282,11 @@ RSpec.describe Draw, type: :model do
       draw = FactoryGirl.build_stubbed(:draw)
       group = instance_spy('Group', leader: instance_spy('User'))
       allow(draw).to receive(:next_groups).and_return([group])
-      mailer = instance_spy('student_mailer')
-      draw.notify_next_groups(mailer)
-      expect(mailer).to have_received(:selection_invite).with(group.leader, nil)
+      msg = instance_spy(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(StudentMailer).to receive(:selection_invite).and_return(msg)
+      draw.notify_next_groups(StudentMailer)
+      expect(StudentMailer).to \
+        have_received(:selection_invite).with(user: group.leader)
     end
     # rubocop:enable RSpec/ExampleLength
   end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -236,4 +236,26 @@ RSpec.describe Group, type: :model do
       expect(group).not_to be_unlockable
     end
   end
+
+  context 'on disbanding' do
+    let(:msg) { instance_spy(ActionMailer::MessageDelivery, deliver_later: 1) }
+    it 'notifies members' do
+      group = FactoryGirl.create(:full_group)
+      allow(StudentMailer).to receive(:disband_notification).and_return(msg)
+      group.destroy
+      expect(StudentMailer).to \
+        have_received(:disband_notification).exactly(group.memberships_count)
+    end
+  end
+
+  context 'on locking' do
+    let(:msg) { instance_spy(ActionMailer::MessageDelivery, deliver_later: 1) }
+    it 'notifies members' do
+      group = FactoryGirl.create(:finalizing_group, size: 2)
+      allow(StudentMailer).to receive(:group_locked).and_return(msg)
+      group.memberships.last.update(locked: true)
+      expect(StudentMailer).to \
+        have_received(:group_locked).exactly(group.memberships_count)
+    end
+  end
 end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -167,4 +167,25 @@ RSpec.describe Membership, type: :model do
       expect(membership).not_to be_valid
     end
   end
+
+  describe 'email callbacks' do
+    let(:msg) { instance_spy(ActionMailer::MessageDelivery, deliver_later: 1) }
+    # rubocop:disable RSpec/ExampleLength
+    it 'emails leader on invitation acceptance' do
+      g = FactoryGirl.create(:open_group)
+      m = Membership.create(user: FactoryGirl.create(:student, draw: g.draw),
+                            group: g, status: 'invited')
+      allow(StudentMailer).to receive(:joined_group).and_return(msg)
+      m.update(status: 'accepted')
+      expect(StudentMailer).to have_received(:joined_group)
+    end
+    # rubocop:enable RSpec/ExampleLength
+    it 'emails leader when someone leaves' do
+      group = FactoryGirl.create(:full_group)
+      m = group.memberships.last
+      allow(StudentMailer).to receive(:left_group).and_return(msg)
+      m.destroy
+      expect(StudentMailer).to have_received(:left_group)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe User, type: :model do
   it 'destroys a dependent membership on destruction' do
     user = FactoryGirl.create(:student, intent: 'on_campus')
     group = FactoryGirl.create(:drawless_group, size: 2)
-    membership_id = Membership.create!(user: user, group: group).id
+    m = Membership.create!(user: user, group: group).id
     user.destroy
-    expect { Membership.find(membership_id) }.to \
+    expect { Membership.find(m) }.to \
       raise_error(ActiveRecord::RecordNotFound)
   end
   # rubocop:enable RSpec/ExampleLength

--- a/spec/services/draw_activator_spec.rb
+++ b/spec/services/draw_activator_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe DrawActivator do
   # we may want to extract this into a shared example if we use this pattern

--- a/spec/services/group_finalizer_spec.rb
+++ b/spec/services/group_finalizer_spec.rb
@@ -6,15 +6,13 @@ RSpec.describe GroupFinalizer do
     xit 'calls #finalize on a new instance'
   end
   context 'successful' do
-    let(:group) do
-      instance_spy('Group', full?: true, size: 3).tap do |g|
-        allow(g).to receive(:draw)
-          .and_return(instance_spy('Draw', open_suite_sizes: [g.size]))
-        membership = instance_spy('Membership', locked: false)
-        leader = instance_spy('User', membership: membership)
-        allow(g).to receive(:leader).and_return(leader)
-      end
+    let(:group) { mock_group }
+
+    before do
+      msg = instance_spy(ActionMailer::MessageDelivery, deliver_later: true)
+      allow(StudentMailer).to receive(:finalizing_notification).and_return(msg)
     end
+
     it 'locks the leader membership' do
       described_class.finalize(group: group)
       expect(group.leader.membership).to \
@@ -31,6 +29,32 @@ RSpec.describe GroupFinalizer do
     it 'returns a success msg' do
       results = described_class.finalize(group: group)
       expect(results[:msg].keys).to eq([:success])
+    end
+    it 'emails the members' do
+      described_class.finalize(group: group)
+      expect(StudentMailer).to \
+        have_received(:finalizing_notification).exactly(group.size - 1)
+    end
+
+    def mock_group
+      instance_spy('Group', full?: true, size: 3).tap do |g|
+        allow(g).to receive(:draw)
+          .and_return(instance_spy('Draw', open_suite_sizes: [g.size]))
+        mock_leader(g)
+        mock_members(g)
+      end
+    end
+
+    def mock_leader(g)
+      membership = instance_spy('Membership', locked: false)
+      leader = instance_spy('User', membership: membership)
+      allow(g).to receive(:leader).and_return(leader)
+    end
+
+    def mock_members(g)
+      m = Array.new(g.size - 1) { |_| instance_spy('user') }
+      m << g.leader
+      allow(g).to receive(:members).and_return(m)
     end
   end
 


### PR DESCRIPTION
Resolves #187, #239, #316
 - Add notification to group members on disband
 - Add member notification to GroupFinalizer
 - Add email when a group locks
 - Add email to leader when accepted memberships change