### PR TITLE
[330] Update housing rep permissions

### DIFF
--- a/app/policies/building_policy.rb
+++ b/app/policies/building_policy.rb
@@ -5,16 +5,8 @@ class BuildingPolicy < ApplicationPolicy
     true
   end
 
-  def update?
-    user.rep? || user.admin?
-  end
-
-  def edit?
-    update?
-  end
-
   def index?
-    user.rep? || user.admin?
+    true
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -23,7 +23,7 @@ class DrawPolicy < ApplicationPolicy
   end
 
   def suites_edit?
-    edit?
+    edit? || user.rep?
   end
 
   def suites_update?

--- a/app/policies/drawless_group_policy.rb
+++ b/app/policies/drawless_group_policy.rb
@@ -9,7 +9,7 @@ class DrawlessGroupPolicy < ApplicationPolicy
   end
 
   def show?
-    record.members.include?(user) || super
+    record.members.include?(user) || user.admin?
   end
 
   private

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -5,14 +5,6 @@ class RoomPolicy < ApplicationPolicy
     true
   end
 
-  def update?
-    user.rep? || user.admin?
-  end
-
-  def index?
-    user.rep? || user.admin?
-  end
-
   class Scope < Scope # rubocop:disable Style/Documentation
     def resolve
       scope

--- a/app/policies/suite_import_form_policy.rb
+++ b/app/policies/suite_import_form_policy.rb
@@ -2,7 +2,7 @@
 # Class for SuiteImport permissions.
 class SuiteImportFormPolicy < ApplicationPolicy
   def import?
-    user.rep? || user.admin?
+    user.admin?
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/policies/suite_policy.rb
+++ b/app/policies/suite_policy.rb
@@ -2,15 +2,7 @@
 # Class for Suite permissions
 class SuitePolicy < ApplicationPolicy
   def show?
-    !record.medical || user.try(:group).try(:suite) == record || user.admin?
-  end
-
-  def update?
-    user.admin?
-  end
-
-  def index?
-    true
+    !record.medical || user&.group&.suite == record || user.admin?
   end
 
   def merge?
@@ -18,7 +10,7 @@ class SuitePolicy < ApplicationPolicy
   end
 
   def perform_merge?
-    edit? || user.rep?
+    edit?
   end
 
   def build_split?
@@ -30,7 +22,15 @@ class SuitePolicy < ApplicationPolicy
   end
 
   def perform_split?
-    (edit? || user.rep?) && record.rooms.size >= 2
+    edit? && record.rooms.size >= 2
+  end
+
+  def view_draw?
+    edit?
+  end
+
+  def medical?
+    user.admin?
   end
 
   class Scope < Scope # rubocop:disable Style/Documentation

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -5,16 +5,9 @@ class UserPolicy < ApplicationPolicy
     user.admin? || user == record
   end
 
-  def update?
-    edit?
-  end
-
-  def edit?
-    user.admin?
-  end
-
   def edit_intent?
-    user.admin? || (user == record && !user.group && draw_intent_state)
+    user.admin? || user.rep? ||
+      (user == record && !user.group && draw_intent_state)
   end
 
   def update_intent?

--- a/app/views/application/_nav_rep.html.erb
+++ b/app/views/application/_nav_rep.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   <% if current_user.group %>
     <li><%= link_to 'My Group', draw_group_path(current_user.draw, current_user.group) %></li>
-  <% elsif policy(Group).new? %>
+  <% elsif policy(Group).new? && current_user.draw %>
     <li><%= link_to 'Create Housing Group', new_draw_group_path(current_user.draw) %></li>
   <% end %>
   <li><%= link_to 'Export Group Leader Emails', new_email_export_path %></li>

--- a/app/views/buildings/_summary_table.html.erb
+++ b/app/views/buildings/_summary_table.html.erb
@@ -5,8 +5,10 @@
       <td>Suite Size</td>
       <td># Suites</td>
       <td># Suites Assigned</td>
-      <td># Suites in Draws</td>
-      <td># Suites not in a Draw</td>
+      <% if policy(Suite).view_draw? %>
+        <td># Suites in Draws</td>
+        <td># Suites not in a Draw</td>
+      <% end %>
     </tr>
   </thead>
   <tbody>
@@ -15,8 +17,10 @@
         <td data-role="suite-size"><%= headerize_size(size) %></td>
         <td data-role="suite-count"><%= suites.count %></td>
         <td data-role="assigned-count"><%= suites.select { |s| s.group_id.present? }.count %></td>
-        <td data-role="draws-count"><%= suites.select { |s| s.draws.present? }.count %></td>
-        <td data-role="not-draw-count"><%= suites.select { |s| s.draws.empty? }.count %></td>
+        <% if policy(Suite).view_draw? %>
+          <td data-role="draws-count"><%= suites.select { |s| s.draws.present? }.count %></td>
+          <td data-role="not-draw-count"><%= suites.select { |s| s.draws.empty? }.count %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/suites/_summary.html.erb
+++ b/app/views/suites/_summary.html.erb
@@ -16,7 +16,7 @@
         </thead>
         <tbody>
           <% suites[size].each do |suite| %>
-            <% next if suite.medical %>
+            <% next if suite.medical && !policy(suite).medical? %>
             <tr id="suite-<%= suite.id %>">
               <td data-role="suite-number"><%= link_to suite.number, suite_path(suite) %></td>
               <td data-role="suite-singles"><%= suite.singles.count %></td>

--- a/app/views/suites/show.html.erb
+++ b/app/views/suites/show.html.erb
@@ -1,13 +1,16 @@
 <h1 class="suite-number"><%= @suite.number %></h1>
-  <% if policy(@suite).edit? %>
-    <span class="label secondary suite-medical" style="margin-bottom: 1em;"><%= medical_str(@suite.medical).capitalize %></span>
-  <% end %>
+<% if policy(@suite).medical? %>
+  <span class="label secondary suite-medical" style="margin-bottom: 1em;"><%= medical_str(@suite.medical).capitalize %></span>
+<% end %>
 <ul>
   <li>Status:
     <% if @suite.available? %>
       Available
     <% else %>
-      Unavailable (Assigned to <%= link_to @group.name, group_path(@group) %>)
+      Unavailable
+      <% if !@suite.medical || policy(@suite).medical? %>
+        (Assigned to <%= link_to @group.name, group_path(@group) %>)
+      <% end %>
     <% end %>
   </li>
   <li>Size: <%= size_str(@suite.size).capitalize %></li>
@@ -40,10 +43,15 @@
 <% if policy(@suite).split? %>
   <p><%= link_to 'Split suite', split_suite_path(@suite) %></p>
 <% end %>
-
-<% if policy(@suite).edit? %>
-  <div>
+<div>
+  <% if policy(@suite).edit? %>
+    <%= link_to 'Edit', edit_suite_path(@suite), class: 'button secondary' %>
+  <% end %>
+  <% if policy(@suite).medical? %>
     <%= render 'medical_form', suite: @suite %>
+  <% end %>
+  <% if policy(@suite).destroy? %>
     <%= link_to 'Delete', suite_path(@suite), method: :delete, class: 'button alert' %>
-  </div>
- <% end %>
+  <% end %>
+</div>
+<p><%= link_to 'Back to building', building_path(@suite.building) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :colleges, only: %i(new create show edit update)
   resources :buildings
   post 'suite_import/import', to: 'suite_imports#import', as: 'suite_import'
-  resources :suites do
+  resources :suites, except: :index do
     member do
       get 'merge'
       post 'merge', to: 'suites#perform_merge'
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
       post 'split', to: 'suites#perform_split'
     end
   end
-  resources :rooms
+  resources :rooms, except: :index
 
   resources :users do
     member do

--- a/spec/policies/building_policy_spec.rb
+++ b/spec/policies/building_policy_spec.rb
@@ -10,33 +10,39 @@ RSpec.describe BuildingPolicy do
     permissions :show? do
       it { is_expected.to permit(user, building) }
     end
-    permissions :create?, :destroy?, :edit?, :update? do
+    permissions :destroy?, :edit?, :update? do
       it { is_expected.not_to permit(user, building) }
     end
     permissions :index? do
+      it { is_expected.to permit(user, Building) }
+    end
+    permissions :new?, :create? do
       it { is_expected.not_to permit(user, Building) }
     end
   end
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
+    permissions :show? do
+      it { is_expected.to permit(user, building) }
+    end
+    permissions :destroy?, :edit?, :update? do
+      it { is_expected.not_to permit(user, building) }
+    end
     permissions :index? do
       it { is_expected.to permit(user, Building) }
     end
-    permissions :show?, :edit?, :update? do
-      it { is_expected.to permit(user, building) }
-    end
-    permissions :create?, :destroy? do
-      it { is_expected.not_to permit(user, building) }
+    permissions :new?, :create? do
+      it { is_expected.not_to permit(user, Building) }
     end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :index? do
+    permissions :new?, :create?, :index? do
       it { is_expected.to permit(user, Building) }
     end
-    permissions :show?, :edit?, :update?, :create?, :destroy? do
+    permissions :show?, :edit?, :update?, :destroy? do
       it { is_expected.to permit(user, building) }
     end
   end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -63,11 +63,14 @@ RSpec.describe DrawPolicy do
     permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
+    permissions :suites_edit?, :suites_update? do
+      it { is_expected.to permit(user, draw) }
+    end
     permissions :create?, :edit?, :update?, :destroy?, :activate?,
-                :intent_report?, :filter_intent_report?, :suites_edit?,
-                :suites_update?, :student_summary?, :students_update?,
-                :oversubscription?, :toggle_size_lock?, :start_lottery?,
-                :lottery_confirmation?, :start_selection?, :bulk_on_campus? do
+                :intent_report?, :filter_intent_report?, :student_summary?,
+                :students_update?, :oversubscription?, :toggle_size_lock?,
+                :start_lottery?, :lottery_confirmation?, :start_selection?,
+                :bulk_on_campus? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :index? do

--- a/spec/policies/email_export_policy_spec.rb
+++ b/spec/policies/email_export_policy_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe EmailExportPolicy do
   end
 
   context 'rep' do
-    let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
+    let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
     permissions :new?, :create? do
-      it { is_expected.not_to permit(user, EmailExport) }
+      it { is_expected.to permit(user, EmailExport) }
     end
   end
 
   context 'admin' do
-    let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
+    let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
     permissions :new?, :create? do
-      it { is_expected.not_to permit(user, EmailExport) }
+      it { is_expected.to permit(user, EmailExport) }
     end
   end
 end

--- a/spec/policies/group_policy_spec.rb
+++ b/spec/policies/group_policy_spec.rb
@@ -246,197 +246,60 @@ RSpec.describe GroupPolicy do
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    let(:group) { FactoryGirl.build_stubbed(:group, leader: user) }
-    let(:other_group) { FactoryGirl.build_stubbed(:group) }
+    let(:group) do
+      FactoryGirl.build_stubbed(:group,
+                                draw: FactoryGirl.build_stubbed(:draw))
+    end
 
     permissions :create? do
-      context 'in pre_lottery draw, not in group, on_campus' do
-        before do
-          draw = instance_spy('draw', pre_lottery?: true)
-          allow(user).to receive(:draw).and_return(draw)
-          allow(user).to receive(:group).and_return(nil)
-          allow(user).to receive(:on_campus?).and_return(true)
-        end
-        it { is_expected.to permit(user, Group) }
-      end
-      context 'in pre_lottery draw, in group, on_campus' do
-        before do
-          draw = instance_spy('draw', pre_lottery?: true)
-          allow(user).to receive(:draw).and_return(draw)
-          allow(user).to receive(:group).and_return(instance_spy('group'))
-          allow(user).to receive(:on_campus?).and_return(true)
-        end
-        it { is_expected.not_to permit(user, Group) }
-      end
-      context 'in pre_lottery draw, not in group, not on_campus' do
-        before do
-          draw = instance_spy('draw', pre_lottery?: true)
-          allow(user).to receive(:draw).and_return(draw)
-          allow(user).to receive(:group).and_return(nil)
-          allow(user).to receive(:on_campus?).and_return(false)
-        end
-        it { is_expected.not_to permit(user, Group) }
-      end
-      context 'in non-pre_lottery' do
-        before do
-          draw = instance_spy('draw', pre_lottery?: false)
-          allow(user).to receive(:draw).and_return(draw)
-        end
-        it { is_expected.not_to permit(user, Group) }
-      end
-      context 'not in draw' do
-        before { allow(user).to receive(:draw).and_return(nil) }
-        it { is_expected.not_to permit(user, Group) }
-      end
+      it { is_expected.to permit(user, Group) }
     end
     permissions :index? do
-      it { is_expected.to permit(user, [group, other_group]) }
+      it { is_expected.to permit(user, [group]) }
     end
-    permissions :show?, :view_pending_members? do
+    permissions :show?, :edit?, :update?, :destroy?, :accept_request?,
+                :advanced_edit?, :view_pending_members?, :reject_pending?,
+                :change_leader?, :select_suite?, :assign_suite? do
       it { is_expected.to permit(user, group) }
-      it { is_expected.to permit(user, other_group) }
     end
-    permissions :destroy?, :edit?, :update?, :accept_request?, :change_leader?,
-                :reject_pending? do
-      context 'not finalizing or locked' do
-        before do
-          allow(group).to receive(:finalizing?).and_return(false)
-          allow(group).to receive(:locked?).and_return(false)
-        end
-        it { is_expected.to permit(user, group) }
-        it { is_expected.not_to permit(user, other_group) }
-      end
-      context 'finalizing' do
-        before do
-          allow(group).to receive(:finalizing?).and_return(true)
-          allow(group).to receive(:locked?).and_return(false)
-        end
-        it { is_expected.not_to permit(user, group) }
-        it { is_expected.not_to permit(user, other_group) }
-      end
-      context 'locked' do
-        before do
-          allow(group).to receive(:finalizing?).and_return(false)
-          allow(group).to receive(:locked?).and_return(true)
-        end
-        it { is_expected.not_to permit(user, group) }
-        it { is_expected.not_to permit(user, other_group) }
-      end
+    permissions :make_drawless? do
+      it { is_expected.not_to permit(user, group) }
     end
     permissions :send_invites?, :invite? do
       context 'group open' do
         before { allow(group).to receive(:open?).and_return(true) }
         it { is_expected.to permit(user, group) }
-        it { is_expected.not_to permit(user, other_group) }
       end
       context 'group not open' do
         before { allow(group).to receive(:open?).and_return(false) }
         it { is_expected.not_to permit(user, group) }
-        it { is_expected.not_to permit(user, other_group) }
       end
     end
-    permissions :request_to_join? do
-      context 'in same draw as record, not in group' do
+    permissions :lock? do
+      context 'lockable group' do
         before do
-          draw = instance_spy('Draw')
-          allow(group).to receive(:draw).and_return(draw)
-          allow(user).to receive(:draw).and_return(draw)
-          allow(user).to receive(:group).and_return(nil)
+          allow(group).to receive(:open?).and_return(false)
+          allow(group).to receive(:locked?).and_return(false)
         end
         it { is_expected.to permit(user, group) }
       end
-      context 'in different draw, not in group' do
-        before do
-          allow(group).to receive(:draw).and_return(instance_spy('Draw'))
-          allow(user).to receive(:draw).and_return(instance_spy('Draw'))
-          allow(user).to receive(:group).and_return(nil)
-        end
+      context 'open group' do
+        before { allow(group).to receive(:open?).and_return(true) }
         it { is_expected.not_to permit(user, group) }
       end
-      context 'in same draw, in group' do
-        before do
-          draw = instance_spy('Draw')
-          allow(group).to receive(:draw).and_return(draw)
-          allow(user).to receive(:draw).and_return(draw)
-          allow(user).to receive(:group).and_return(instance_spy('Group'))
-        end
+      context 'locked group' do
+        before { allow(group).to receive(:locked?).and_return(true) }
         it { is_expected.not_to permit(user, group) }
       end
     end
-    permissions :accept_invitation? do
-      context 'invited, not in group' do
-        before do
-          allow(other_group).to receive(:invitations).and_return([user])
-          allow(user).to receive(:group).and_return(nil)
-        end
-        it { is_expected.to permit(user, other_group) }
+    permissions :unlock? do
+      context 'unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(true) }
+        it { is_expected.to permit(user, group) }
       end
-      context 'in draw, in group' do
-        before do
-          allow(user).to receive(:group).and_return(group)
-          allow(other_group).to receive(:invitations).and_return([user])
-        end
-        it { is_expected.not_to permit(user, other_group) }
-      end
-    end
-    permissions :leave? do
-      context 'in group, not leader' do
-        before do
-          allow(other_group).to receive(:members).and_return([user])
-          allow(other_group).to receive(:leader)
-            .and_return(instance_spy('user'))
-        end
-        it { is_expected.to permit(user, other_group) }
-      end
-      context 'in locked_group, not leader' do
-        before do
-          allow(other_group).to receive(:members).and_return([user])
-          allow(other_group).to receive(:locked?).and_return(true)
-        end
-        it { is_expected.not_to permit(user, other_group) }
-      end
-      context 'in group, leader' do
-        before { allow(group).to receive(:members).and_return([user]) }
+      context 'not unlockable group' do
+        before { allow(group).to receive(:unlockable?).and_return(false) }
         it { is_expected.not_to permit(user, group) }
-      end
-      context 'not in group' do
-        before { allow(other_group).to receive(:members).and_return([]) }
-        it { is_expected.not_to permit(user, other_group) }
-      end
-    end
-    permissions :finalize? do
-      before { allow(group).to receive(:full?).and_return(true) }
-      it { is_expected.to permit(user, group) }
-    end
-    permissions :finalize_membership? do
-      context 'in finalizing group, accepted membership' do
-        before do
-          allow(user).to receive(:group).and_return(other_group)
-          allow(other_group).to receive(:finalizing?).and_return(true)
-        end
-        it { is_expected.to permit(user, other_group) }
-      end
-      context 'in finalizing group, pending membership' do
-        before do
-          allow(user).to receive(:group).and_return(nil)
-          allow(other_group).to receive(:finalizing?).and_return(true)
-        end
-        it { is_expected.not_to permit(user, other_group) }
-      end
-      context 'in full group, accepted membership' do
-        before do
-          allow(user).to receive(:group).and_return(other_group)
-          allow(other_group).to receive(:finalizing?).and_return(false)
-        end
-        it { is_expected.not_to permit(user, other_group) }
-      end
-      context 'already locked membership' do
-        before do
-          allow(user).to receive(:group).and_return(other_group)
-          allow(other_group).to receive(:finalizing?).and_return(true)
-          allow(other_group).to receive(:locked_members).and_return([user])
-        end
-        it { is_expected.not_to permit(user, other_group) }
       end
     end
     permissions :assign_lottery? do
@@ -449,47 +312,28 @@ RSpec.describe GroupPolicy do
         it { is_expected.not_to permit(user, group) }
       end
     end
+    permissions :request_to_join?, :finalize_membership? do
+      it { is_expected.not_to permit(user, group) }
+    end
+    permissions :finalize? do
+      before { allow(group).to receive(:full?).and_return(true) }
+      it { is_expected.to permit(user, group) }
+    end
     permissions :assign_rooms? do
       before do
         suite = instance_spy('suite', present?: true)
         allow(group).to receive(:suite).and_return(suite)
-        allow(user).to receive(:group).and_return(group)
-        allow(user).to receive(:room_id).and_return(nil)
+        leader = instance_spy('user', room_id: nil)
+        allow(group).to receive(:leader).and_return(leader)
       end
       it { is_expected.to permit(user, group) }
-      it { is_expected.not_to permit(user, other_group) }
     end
-    permissions :lock?, :advanced_edit?, :unlock?, :make_drawless?,
-                :edit_room_assignment? do
-      it { is_expected.not_to permit(user, other_group) }
+    permissions :edit_room_assignment? do
+      before do
+        leader = instance_spy('user', room_id: 123)
+        allow(group).to receive(:leader).and_return(leader)
+      end
       it { is_expected.not_to permit(user, group) }
-    end
-    permissions :select_suite?, :assign_suite? do
-      context 'next group, group leader' do
-        before do
-          draw = instance_spy('Draw')
-          allow(draw).to receive(:next_group?).with(group).and_return(true)
-          allow(group).to receive(:draw).and_return(draw)
-        end
-        it { is_expected.to permit(user, group) }
-      end
-      context 'group leader, not next group' do
-        before do
-          draw = instance_spy('Draw')
-          allow(draw).to receive(:next_group?).with(group).and_return(false)
-          allow(group).to receive(:draw).and_return(draw)
-        end
-        it { is_expected.not_to permit(user, group) }
-      end
-      context 'next group, not leader' do
-        before do
-          draw = instance_spy('Draw')
-          allow(draw).to receive(:next_group?).with(other_group)
-            .and_return(true)
-          allow(other_group).to receive(:draw).and_return(draw)
-        end
-        it { is_expected.not_to permit(user, other_group) }
-      end
     end
   end
 

--- a/spec/policies/room_policy_spec.rb
+++ b/spec/policies/room_policy_spec.rb
@@ -10,33 +10,33 @@ RSpec.describe RoomPolicy do
     permissions :show? do
       it { is_expected.to permit(user, room) }
     end
-    permissions :create?, :destroy?, :edit?, :update? do
+    permissions :destroy?, :edit?, :update? do
       it { is_expected.not_to permit(user, room) }
     end
-    permissions :index? do
+    permissions :new?, :create?, :index? do
       it { is_expected.not_to permit(user, Room) }
     end
   end
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show?, :edit?, :update? do
+    permissions :show? do
       it { is_expected.to permit(user, room) }
     end
-    permissions :index? do
-      it { is_expected.to permit(user, Room) }
+    permissions :new?, :create?, :index? do
+      it { is_expected.not_to permit(user, Room) }
     end
-    permissions :create?, :destroy? do
+    permissions :destroy?, :edit?, :update? do
       it { is_expected.not_to permit(user, room) }
     end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :show?, :edit?, :update?, :create?, :destroy? do
+    permissions :show?, :edit?, :update?, :destroy? do
       it { is_expected.to permit(user, room) }
     end
-    permissions :index? do
+    permissions :new?, :create?, :index? do
       it { is_expected.to permit(user, Room) }
     end
   end

--- a/spec/policies/suite_import_form_policy_spec.rb
+++ b/spec/policies/suite_import_form_policy_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SuiteImportFormPolicy do
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
     permissions :import? do
-      it { is_expected.to permit(user, SuiteImportForm) }
+      it { is_expected.not_to permit(user, SuiteImportForm) }
     end
   end
 

--- a/spec/policies/suite_policy_spec.rb
+++ b/spec/policies/suite_policy_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe SuitePolicy do
         it { is_expected.not_to permit(user, suite) }
       end
     end
-    permissions :index? do
-      it { is_expected.to permit(user, Suite) }
+    permissions :new?, :create?, :view_draw? do
+      it { is_expected.not_to permit(user, Suite) }
     end
-    permissions :create?, :destroy?, :edit?, :update?, :merge?,
-                :perform_merge?, :build_split?, :split?, :perform_split? do
+    permissions :destroy?, :edit?, :update?, :merge?, :perform_merge?,
+                :build_split?, :split?, :perform_split?, :medical? do
       it { is_expected.not_to permit(user, suite) }
     end
   end
@@ -38,43 +38,24 @@ RSpec.describe SuitePolicy do
         it { is_expected.not_to permit(user, suite) }
       end
     end
-    permissions :merge?, :perform_merge? do
-      it { is_expected.to permit(user, suite) }
+    permissions :new?, :create?, :view_draw? do
+      it { is_expected.not_to permit(user, Suite) }
     end
-    permissions :index? do
-      it { is_expected.to permit(user, Suite) }
-    end
-    permissions :create?, :destroy? do
+    permissions :merge?, :perform_merge?, :build_split?, :split?,
+                :perform_split?, :destroy?, :medical? do
       it { is_expected.not_to permit(user, suite) }
-    end
-
-    permissions :build_split?, :split?, :perform_split? do
-      context 'suite has fewer than two rooms' do
-        before do
-          allow(suite).to receive(:rooms).and_return([instance_spy('Room')])
-        end
-        it { is_expected.not_to permit(user, suite) }
-      end
-      context 'suite has at least two rooms' do
-        before do
-          allow(suite).to receive(:rooms)
-            .and_return([instance_spy('Room'), instance_spy('Room')])
-        end
-        it { is_expected.to permit(user, suite) }
-      end
     end
   end
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
-    permissions :show?, :edit?, :update?, :create?, :destroy?, :merge?,
-                :perform_merge? do
+    permissions :show?, :edit?, :update?, :destroy?, :merge?, :perform_merge?,
+                :medical? do
       it { is_expected.to permit(user, suite) }
     end
-    permissions :index? do
+    permissions :new?, :create?, :view_draw? do
       it { is_expected.to permit(user, Suite) }
     end
-
     permissions :build_split?, :split?, :perform_split? do
       context 'suite has fewer than two rooms' do
         before do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -99,18 +99,8 @@ RSpec.describe UserPolicy do
         allow(user).to receive(:draw).and_return(draw)
       end
       permissions :edit_intent?, :update_intent? do
-        context 'user in group' do # rubocop:disable RSpec/NestedGroups
-          before do
-            allow(user).to receive(:group).and_return(instance_spy('group'))
-          end
-          it { is_expected.not_to permit(user, user) }
-        end
-        context 'user not in group' do # rubocop:disable RSpec/NestedGroups
-          before do
-            allow(user).to receive(:group).and_return(nil)
-          end
-          it { is_expected.to permit(user, user) }
-        end
+        it { is_expected.to permit(user, user) }
+        it { is_expected.to permit(user, other_user) }
       end
     end
     context 'draw not pre-lottery status' do
@@ -121,7 +111,8 @@ RSpec.describe UserPolicy do
         allow(user).to receive(:draw).and_return(draw)
       end
       permissions :edit_intent?, :update_intent? do
-        it { is_expected.not_to permit(user, user) }
+        it { is_expected.to permit(user, user) }
+        it { is_expected.to permit(user, other_user) }
       end
     end
     context 'draw intent locked' do
@@ -132,11 +123,11 @@ RSpec.describe UserPolicy do
         allow(user).to receive(:draw).and_return(draw)
       end
       permissions :edit_intent?, :update_intent? do
-        it { is_expected.not_to permit(user, user) }
+        it { is_expected.to permit(user, user) }
+        it { is_expected.to permit(user, other_user) }
       end
     end
-    permissions :show?, :create?, :destroy?, :update?, :edit?,
-                :edit_intent?, :update_intent? do
+    permissions :show?, :create?, :destroy?, :update?, :edit? do
       it { is_expected.not_to permit(user, other_user) }
     end
     permissions :index?, :build? do


### PR DESCRIPTION
Resolves #330
- Adjust permissions as per discussions with Dean's Office
- Clean up cases of checking :new? and :create? on an instance instead
  of the class
- Remove :index routes for Rooms and Suites