### PR TITLE
[307] Clean up DrawlessGroups#show

### DIFF
--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -6,8 +6,9 @@ class DrawlessGroupsController < ApplicationController
   before_action :set_form_data, only: %i(new edit)
 
   def show
-    @compatible_suites = Suite.available.where(size: @group.size)
-    @compatible_suites_no_draw = @compatible_suites.where(draw_id: [])
+    @compatible_suites = Suite.available.where(size: @group.size).order(:number)
+    @compatible_suites_no_draw = @compatible_suites.includes(:draws)
+                                                   .where(draws: { id: nil })
     @compatible_suites_in_draw = @compatible_suites - @compatible_suites_no_draw
 
     render layout: 'application_with_sidebar'

--- a/app/helpers/drawless_groups_helper.rb
+++ b/app/helpers/drawless_groups_helper.rb
@@ -2,12 +2,6 @@
 #
 # Helper module for drawless groups
 module DrawlessGroupsHelper
-  def suite_collection(group)
-    available = Suite.available.order(:number).to_a
-    return available unless group.suite
-    available.insert(0, group.suite)
-  end
-
   def suite_str(group)
     return "Suite: #{group.suite.number}" if group.suite.present?
     'Assign suite'

--- a/app/views/drawless_groups/show.html.erb
+++ b/app/views/drawless_groups/show.html.erb
@@ -1,20 +1,22 @@
 <%= render partial: 'groups/group_details' %>
 <% if policy(DrawlessGroup.new(@group)).select_suite? %>
-  <h2><%= suite_str(@group) %></h2>
-  <% if @group.suite %>
+  <h3><%= suite_str(@group) %></h3>
+  <% if @group.suite.present? %>
     <%= simple_form_for @group, url: select_suite_group_path(@group), method: :patch do |f| %>
       <%= f.input :suite, as: :hidden, input_html: { value: '' } %>
       <%= f.submit 'Remove suite' %>
     <% end %>
   <% else %>
     <%= simple_form_for @group, url: select_suite_group_path(@group), method: :patch do |f| %>
-      <%= f.input :suite, collection: suite_collection(@group), label_method: :number, selected: @group.suite.try(:id) %>
+      <%= f.input :suite, collection: @compatible_suites, label_method: :number, selected: @group.suite.try(:id) %>
       <%= f.submit 'Assign suite' %>
     <% end %>
   <% end %>
+<% elsif @group.suite.present? %>
+  <h3>Suite: <%= @group.suite.number %></h3>
 <% end %>
-<div style="border-top: 1px solid #DDDDDD;">
-  <br />
+<hr />
+<div>
   <%= link_to 'Edit', edit_group_path(@group), class: 'button secondary' if policy(@group).edit? %>
   <% if policy(@group).lock? %>
     <%= link_to 'Lock Group', lock_group_path(@group), method: :put, class: 'button alert' %>

--- a/spec/helpers/drawless_groups_helper_spec.rb
+++ b/spec/helpers/drawless_groups_helper_spec.rb
@@ -3,34 +3,6 @@ require 'rails_helper'
 require 'simple_form'
 
 RSpec.describe DrawlessGroupsHelper, tyep: :helper do
-  describe '#suite_collection' do
-    it 'returns a sorted list of available suites if no suite assigned' do
-      expected = mock_suite_list(%w(112 24 12))
-      group = instance_spy('group', suite: nil)
-      expect(helper.suite_collection(group)).to eq(expected)
-    end
-    it 'returns a sorted list with the group suite at the start' do
-      available_sorted = mock_suite_list(%w(112 24 12))
-      suite = FactoryGirl.create(:suite, number: '1242', group_id: 123)
-      group = instance_spy('group', suite: suite)
-      expect(helper.suite_collection(group)).to \
-        eq([suite] + available_sorted)
-    end
-
-    def mock_suite_list(suite_numbers) # rubocop:disable AbcSize
-      suite_list = suite_numbers.map do |n|
-        FactoryGirl.create(:suite, number: n)
-      end
-      instance_spy('ActiveRecord::Relation').tap do |suite_relation|
-        result = instance_spy('ActiveRecord::Relation',
-                              to_a: suite_list.sort_by!(&:number))
-        allow(suite_relation).to receive(:order).and_return(result)
-        allow(Suite).to receive(:available).and_return(suite_relation)
-      end
-      suite_list.sort_by(&:number)
-    end
-  end
-
   describe '#suite_str' do
     it 'returns a generic heading if no suite assigned' do
       group = instance_spy('Group', suite: nil)


### PR DESCRIPTION
Resolves #307
- Use h3 instead of h2
- Remove unnecessary helper method from DrawlessGroupsHelper
- Fix incorrect query in DrawlessGroupsController#show