### PR TITLE
[341] Add back / cancel links where necessary

### DIFF
--- a/app/views/buildings/edit.html.erb
+++ b/app/views/buildings/edit.html.erb
@@ -1,2 +1,3 @@
 <h1>Edit Building <%= @building.name %></h1>
 <%= render "form", building: @building %>
+<%= link_to 'Cancel', building_path(@building) %>

--- a/app/views/buildings/new.html.erb
+++ b/app/views/buildings/new.html.erb
@@ -1,3 +1,4 @@
 <h1> New Building </h1>
 <%= render "form", building: @building %>
+<%= link_to 'Cancel', buildings_path %>
 

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -30,3 +30,4 @@ and Doubles is the number of double bedrooms in the suite.</p>
     <%= link_to 'Delete', building_path(@building), method: :delete, data: { confirm: 'Are you sure you want to delete this building?' }, class: 'button alert' %>
   <% end %>
 </div>
+<%= link_to 'View all buildings', buildings_path %>

--- a/app/views/colleges/edit.html.erb
+++ b/app/views/colleges/edit.html.erb
@@ -1,2 +1,3 @@
 <h1>Edit <%= @college.name %> Settings</h1>
 <%= render "form", college: @college %>
+<%= link_to 'Cancel', college_path(@college) %>

--- a/app/views/drawless_groups/edit.html.erb
+++ b/app/views/drawless_groups/edit.html.erb
@@ -1,1 +1,3 @@
-<%= render template: 'groups/edit' %>
+<h1>Edit <%= @group.name %></h1>
+<%= render 'form', group: @group %>
+<%= link_to 'Cancel', group_path(@group) %>

--- a/app/views/drawless_groups/new.html.erb
+++ b/app/views/drawless_groups/new.html.erb
@@ -1,2 +1,3 @@
 <h1>New Special Group</h1>
 <%= render 'form', group: @group %>
+<%= link_to 'Cancel', groups_path %>

--- a/app/views/draws/edit.html.erb
+++ b/app/views/draws/edit.html.erb
@@ -1,2 +1,3 @@
-<h1>Edit Draw <%= @draw.name %></h1>
+<h1>Edit Draw</h1>
 <%= render "form", draw: @draw %>
+<%= link_to 'Cancel', draw_path(@draw) %>

--- a/app/views/draws/intent_report.html.erb
+++ b/app/views/draws/intent_report.html.erb
@@ -30,4 +30,4 @@
     </tbody>
   </table>
 </div>
-<%= link_to 'Back to draw', draw_path(@draw) %>
+<%= link_to 'Return to draw', draw_path(@draw) %>

--- a/app/views/draws/lottery.html.erb
+++ b/app/views/draws/lottery.html.erb
@@ -10,4 +10,4 @@
 <% if policy(@draw).start_selection? %>
   <%= link_to 'Start suite selection', start_selection_draw_path(@draw), method: :patch, data: { confirm: 'Are you sure that you have finished assigning lottery numbers? They cannot be changed after you proceed!' }, class: 'button' %>
 <% end %>
-<p><%= link_to 'Back to draw', draw_path(@draw) %></p>
+<p><%= link_to 'Return to draw', draw_path(@draw) %></p>

--- a/app/views/draws/lottery_confirmation.html.erb
+++ b/app/views/draws/lottery_confirmation.html.erb
@@ -17,7 +17,7 @@
   <hr />
 <% end %>
 <div>
-  <%= link_to 'Back', draw_path(@draw), class: 'button secondary' %>
   <%= link_to 'Proceed to Lottery', start_lottery_draw_path(@draw),
     method: :patch, data: { confirm: 'Are you sure you want to proceed to the lottery? This cannot be undone!' }, class: start_lottery_btn_class(@draw) %>
+  <%= link_to 'Cancel', draw_path(@draw), class: 'button secondary' %>
 </div>

--- a/app/views/draws/new.html.erb
+++ b/app/views/draws/new.html.erb
@@ -1,2 +1,3 @@
 <h1> New Draw </h1>
 <%= render "form", draw: @draw %>
+<%= link_to 'Cancel', draws_path %>

--- a/app/views/draws/oversubscription.html.erb
+++ b/app/views/draws/oversubscription.html.erb
@@ -5,4 +5,4 @@
                                suite_counts: @suite_counts, actions_partial: 'groups/actions',
                                path: oversub_draw_path(@draw) %>
 </div>
-<%= link_to 'Back to draw', draw_path(@draw) %>
+<%= link_to 'Return to draw', draw_path(@draw) %>

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -123,3 +123,4 @@
                 data: { confirm: 'Are you sure you want to delete this draw? You will lose all group, lottery, and suite assignment information!' }, class: 'button alert' %>
   <% end %>
 </div>
+<%= link_to 'View all draws', draws_path %>

--- a/app/views/draws/suites_edit.html.erb
+++ b/app/views/draws/suites_edit.html.erb
@@ -12,4 +12,4 @@
 <%= f.submit 'Update' %>
 <% end %>
 <hr />
-<%= link_to 'Back to suite summary', suite_summary_draw_path(@draw) %>
+<%= link_to 'Cancel', suite_summary_draw_path(@draw) %>

--- a/app/views/enrollments/new.html.erb
+++ b/app/views/enrollments/new.html.erb
@@ -1,7 +1,8 @@
 <h1>Add users</h1>
-<h2>Instructions</h2>
+<h3>Instructions</h3>
 <p>Please enter a list of NetIDs, either separated by commas or one per line (you can copy and paste a list out of Excel, for example). The system will attempt to look them up in Yale's directory and create user accounts for them if they are found.</p>
 <%= simple_form_for @enrollment do |f| %>
   <%= f.input :ids, as: :text %>
   <%= f.submit 'Submit' %>
 <% end %>
+<%= link_to 'Cancel', users_path %>

--- a/app/views/enrollments/results.html.erb
+++ b/app/views/enrollments/results.html.erb
@@ -1,5 +1,5 @@
 <h1>Enrollment Results</h1>
-<h2>The following users were successfully added</h2>
+<h3>The following users were successfully added</h3>
 <table>
   <thead>
     <tr>
@@ -28,4 +28,4 @@
     <% end %>
   </tbody>
 </table>
-
+<%= link_to 'Import more students', new_enrollment_path %>

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,2 +1,3 @@
 <h1>Edit <%= @group.name %></h1>
 <%= render "form", group: @group %>
+<%= link_to 'Cancel', draw_group_path(@draw, @group) %>

--- a/app/views/groups/invite.html.erb
+++ b/app/views/groups/invite.html.erb
@@ -2,3 +2,4 @@
   <%= f.input :invitations, label: 'Students to invite', as: :check_boxes, label_method: :full_name, collection: @students %>
   <%= f.button :submit, 'Send Invitations' %>
 <% end %>
+<%= link_to 'Return to group', draw_group_path(@draw, @group) %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,7 +1,7 @@
-<h1> New Group </h1>
+<h1>New Group</h1>
 <%= render "form", group: @group %>
+<%= link_to 'Cancel', draw_path(@draw) %>
 
 <% content_for :sidebar do %>
   <h3>Insert Draw Summary here</h3>
 <% end %>
-<%= link_to 'Back to draw', draw_path(@draw) %>

--- a/app/views/rooms/edit.html.erb
+++ b/app/views/rooms/edit.html.erb
@@ -1,2 +1,3 @@
 <h1>Edit Room <%= @room.number %></h1>
 <%= render "form", room: @room %>
+<%= link_to 'Cancel', room_path(@room) %>

--- a/app/views/rooms/new.html.erb
+++ b/app/views/rooms/new.html.erb
@@ -1,2 +1,3 @@
-<h1> New Room </h1>
+<h1>New Room</h1>
 <%= render "form", room: @room %>
+<%= link_to 'Cancel', buildings_path %>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -8,3 +8,4 @@
     <%= link_to 'Delete', room_path(@room), method: :delete, data: { confirm: 'Are you sure you want to delete this room?' }, class: 'button alert' %>
   <% end %>
 </div>
+<%= link_to 'Return to suite', suite_path(@room.suite) %>

--- a/app/views/suites/edit.html.erb
+++ b/app/views/suites/edit.html.erb
@@ -1,2 +1,3 @@
 <h1>Edit Suite <%= @suite.number %></h1>
 <%= render "form", suite: @suite %>
+<%= link_to 'Cancel', suite_path(@suite) %>

--- a/app/views/suites/merge.html.erb
+++ b/app/views/suites/merge.html.erb
@@ -10,3 +10,4 @@
   </ul>
   <%= f.submit 'Merge' %>
 <% end %>
+<%= link_to 'Cancel', suite_path(@suite) %>

--- a/app/views/suites/new.html.erb
+++ b/app/views/suites/new.html.erb
@@ -1,3 +1,3 @@
 <h1> New Suite </h1>
 <%= render "form", suite: @suite %>
-
+<%= link_to 'Cancel', buildings_path %>

--- a/app/views/suites/show.html.erb
+++ b/app/views/suites/show.html.erb
@@ -52,4 +52,4 @@
     <%= link_to 'Delete', suite_path(@suite), method: :delete, data: { confirm: 'Are you sure you want to delete this suite?' }, class: 'button alert' %>
   <% end %>
 </div>
-<p><%= link_to 'Back to building', building_path(@suite.building) %></p>
+<%= link_to 'Return to building', building_path(@suite.building) %>

--- a/app/views/suites/split.html.erb
+++ b/app/views/suites/split.html.erb
@@ -6,4 +6,4 @@
   <% end %>
   <%= f.submit 'Split suite' %>
 <% end %>
-<p><%= link_to 'Back to suite', suite_path(@suite) %>
+<p><%= link_to 'Cancel', suite_path(@suite) %>

--- a/app/views/users/build.html.erb
+++ b/app/views/users/build.html.erb
@@ -3,3 +3,4 @@
   <%= f.input :username %>
   <%= f.submit 'Continue' %>
 <% end %>
+<%= link_to 'Cancel', users_path %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<h1> Editing <%= @user.name %> </h1>
+<h1>Editing <%= @user.name %></h1>
 <%= simple_form_for @user do |f| %>
   <%= f.input :first_name %>
   <%= f.input :last_name %>
@@ -6,3 +6,4 @@
   <%= f.input :role, collection: User.roles.keys %>
   <%= f.submit 'Save' %>
 <% end %>
+<%= link_to 'Cancel', user_path(@user) %>

--- a/app/views/users/edit_intent.html.erb
+++ b/app/views/users/edit_intent.html.erb
@@ -1,5 +1,6 @@
-<h1> Declare Housing Intent </h1>
+<h1>Declare Housing Intent</h1>
 <%= simple_form_for @user, url: update_intent_user_path(@user) do |f| %>
   <%= f.input :intent, collection: User.intents.keys %>
   <%= f.submit 'Submit Intent' %>
 <% end %>
+<%= link_to 'Cancel', user_path(@user) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,3 +12,4 @@
   <%= f.input :role, collection: User.roles.keys %>
   <%= f.submit %>
 <% end %>
+<%= link_to 'Cancel', users_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,3 +13,4 @@
     <% end %>
   </div>
 <% end %>
+<%= link_to 'View all users', users_path %>


### PR DESCRIPTION
Resolves #341 

There are going to be so many merge conflicts 😢. I left TODO's on the room and suite new pages since we currently can't redirect back to parent resource (e.g. suite and room, respectively), but we will be able to once we properly nest resources in #431. At the moment I added cancel links that go back to the buildings index, but I'm not sure that even makes sense. Let me know what you think!