### PR TITLE
[162] Add automatic secondary draws for ungrouped students

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 * Ensure that all group reports display correctly ([#487](https://github.com/YaleSTC/vesta/issues/487)).
 * Ensure that NextGroupsQuery ignores groups with no lottery number set ([#504](https://github.com/YaleSTC/vesta/issues/504)).
 
+### Added
+* Create secondary draws to handle ungrouped students after suite selection ([#162](https://github.com/YaleSTC/vesta/issues/162)).
+
 ### Changed
 * Allow reps to handle oversubscription and lock sizes ([#496](https://github.com/YaleSTC/vesta/issues/496)).
 * Allow students to easily navigate to the draw index ([#519](https://github.com/YaleSTC/vesta/issues/519)).

--- a/app/controllers/drawless_groups_controller.rb
+++ b/app/controllers/drawless_groups_controller.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
-#
+
 # Controller class for 'special' (admin-created outside of draw) housing groups.
 class DrawlessGroupsController < ApplicationController
   prepend_before_action :set_group, except: %i(new create index)
   before_action :set_form_data, only: %i(new edit)
 
   def show
+    if @group.draw.present?
+      redirect_to(draw_group_path(@group.draw, @group)) && return
+    end
     @compatible_suites = Suite.available.where(size: @group.size).order(:number)
     @compatible_suites_no_draw = @compatible_suites.includes(:draws)
                                                    .where(draws: { id: nil })

--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -145,9 +145,10 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
   def select_suites
     @groups = @draw.next_groups
     if @groups.empty?
+      result = DrawResultsStarter.start(draw: @draw)
       @draw.update!(status: 'results')
       flash[:success] = 'All groups have suites!'
-      redirect_to draw_path(@draw)
+      handle_action(**result) && return
     end
     @suite_selector = BulkSuiteSelectionForm.new(groups: @groups)
     draw_suites = @draw.suites.available.where(size: @groups.map(&:size))

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -135,7 +135,11 @@ class GroupsController < ApplicationController
 
   def assign_suite
     suite_id = group_params['suite']
-    result = GroupSuiteSelector.select(group: @group, suite_id: suite_id)
+    result = if suite_id.empty? || policy(@draw).select_suites?
+               SuiteRemover.remove(group: @group)
+             else
+               GroupSuiteSelector.select(group: @group, suite_id: suite_id)
+             end
     handle_action(action: 'select_suite', **result)
   end
 

--- a/app/services/draw_results_starter.rb
+++ b/app/services/draw_results_starter.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Service object to handle the starting of the results phase for a draw. Checks
+# to make sure that the draw has the correct status and has enough beds for
+# students, as well as no ungrouped students, and updates the status.
+class DrawResultsStarter
+  include ActiveModel::Model
+
+  # validates :draw, presence: :true
+  validate :draw_in_selection_phase
+  validate :no_more_suiteless_groups
+
+  # Class method to permit calling :start on the class without instantiating the
+  # service object directly
+  def self.start(**params)
+    new(**params).start
+  end
+
+  # Initialize a new DrawResultsStarter
+  #
+  # @param draw [Draw] the draw in question
+  def initialize(draw:, mailer: StudentMailer)
+    @draw = draw
+    @mailer = mailer
+    @college = College.first
+  end
+
+  # Start the results phase of a Draw and create a duplicate draw if necessary
+  # for ungrouped students
+  #
+  #
+  # @return [Hash{Symbol=>ApplicationRecord,Hash}] A results hash with the
+  #   message to set in the flash and either `nil` or the modified object.
+  def start
+    return error unless valid?
+    @new_draw = ActiveRecord::Base.transaction do
+      draw.update!(status: 'results')
+      next nil if draw.all_students_grouped?
+      duplicate_draw
+    end
+    success
+  rescue ActiveRecord::ActiveRecordError => e
+    errors.add(:base, "Draw update failed: #{e.message}")
+    error
+  end
+
+  private
+
+  attr_reader :new_draw
+  attr_accessor :draw
+
+  def draw_in_selection_phase
+    return if draw.nil? || draw.suite_selection?
+    errors.add(:draw, 'must be in the selection phase')
+  end
+
+  def no_more_suiteless_groups
+    return if draw.nil? || draw.all_groups_have_suites?
+    errors.add(:base, 'All groups must have suites selected')
+  end
+
+  # Note: this occurs in a transaction
+  def duplicate_draw # rubocop:disable AbcSize
+    d = Draw.create!(name: draw.name + ' (oversub)', status: 'pre_lottery')
+    draw.ungrouped_students.each do |s|
+      s.remove_draw.update!(draw_id: d.id, intent: 'on_campus')
+    end
+    d.suites << draw.suites.available
+  end
+
+  def success
+    msg = if new_draw
+            success_msg.merge(secondary_draw_warning)
+          else
+            success_msg
+          end
+    { object: draw, msg: msg }
+  end
+
+  def success_msg
+    { success: 'All groups have suites!' }
+  end
+
+  def secondary_draw_warning
+    { notice: 'A new draw has been created with all ungrouped students.' }
+  end
+
+  def error
+    msg = "There was a problem completing suite selection:\n#{error_msgs}"
+    { object: nil, msg: { error: msg } }
+  end
+
+  def error_msgs
+    errors.full_messages.join(', ')
+  end
+end

--- a/app/services/draw_selection_starter.rb
+++ b/app/services/draw_selection_starter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-#
-# Service object to handle the starting of the lottery phase for a draw. Checks
-# to make sure that the draw has the correct status and has enough beds for
-# students, as well as no ungrouped students, and updates the status.
+
+# Service object to handle the starting of the suite selection phase for a draw.
+# Checks to make sure that the draw is in the correct phase and that the lottery
+# is complete. Notifies the first groups for suite selection.
 class DrawSelectionStarter
   include ActiveModel::Model
 

--- a/app/views/draws/select_suites.html.erb
+++ b/app/views/draws/select_suites.html.erb
@@ -3,9 +3,15 @@
 <p>Please select suites for each of the following groups, which have been assigned the lottery number <%= @groups.first.lottery_number %>. If there are insufficient suites available for the given size you may disband the groups of that size before proceeding.</p>
 <%= simple_form_for @suite_selector, url: assign_suites_draw_path(@draw), method: :patch do |f| %>
   <% @groups.each do |group| %>
-    <div id="group-fields-<%= group.id %>">
-      <%= f.input "suite_id_for_#{group.id}".to_sym, label: group.name, as: :select, collection: @suites_by_size[group.size], label_method: :number %>
-      <%= link_to 'Disband', draw_group_path(@draw, group, redirect_path: select_suites_draw_path(@draw)), method: :delete, data: { confirm: 'Are you sure you want to disband this group?' }, class: 'button alert' %>
+    <div id="group-fields-<%= group.id %>" class="actions">
+      <h3 style="display: inline-block; margin-right: 0.3em;"><%= group.name %></h3>
+      <%= link_to 'Disband', draw_group_path(@draw, group, redirect_path: select_suites_draw_path(@draw)), method: :delete, data: { confirm: 'Are you sure you want to disband this group?' }, class: 'button alert small' %>
+      <% if @suites_by_size[group.size] %>
+        <%= f.label "suite_id_for_#{group.id}".to_sym, text: group.name, style: 'display: none;' %>
+        <%= f.input "suite_id_for_#{group.id}".to_sym, label: false, as: :select, collection: @suites_by_size[group.size], label_method: :number %>
+      <% else %>
+        <p>There are no more suites of size <%= group.size %> available. You must disband this group to proceed and its members will have to regroup following this draw.</p>
+      <% end %>
     </div>
     <hr />
   <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -46,6 +46,12 @@
   <%= link_to 'Finalize Membership', finalize_membership_draw_group_path(@draw, @group), method: :put, class: 'button' if policy(@group).finalize_membership? %>
   <%= link_to 'Lock Group', lock_draw_group_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).lock? %>
   <%= link_to 'Unlock All Members', unlock_draw_group_path(@draw, @group), method: :put, class: 'button alert' if policy(@group).unlock? %>
+  <% if @group.suite.present? && policy(@draw).select_suites? %>
+    <%= simple_form_for @group, url: assign_suite_draw_group_path(@draw, @group), method: :patch, html: { class: 'hidden-form' } do |f| %>
+      <%= f.input :suite, as: :hidden, input_html: { value: '' } %>
+      <%= f.submit 'Remove suite' %>
+    <% end %>
+  <% end %>
   <% if policy(@group).assign_rooms? %>
     <%= link_to 'Assign rooms', new_group_room_assignment_path(@group), class: 'button' %>
   <% end %>

--- a/spec/features/draws/draw_suite_selection_spec.rb
+++ b/spec/features/draws/draw_suite_selection_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Draw suite selection' do
   let(:draw) { FactoryGirl.create(:draw_in_selection, groups_count: 3) }
   let(:groups) { draw.groups.order(:lottery_number) }
   let(:suites) { draw.suites }
+
   before do
     groups.first.update(lottery_number: 1)
     log_in FactoryGirl.create(:admin)
@@ -26,10 +28,19 @@ RSpec.feature 'Draw suite selection' do
                              text: "Group #{groups.first.name} deleted")
   end
 
+  it 'creates secondary draws if necessary' do
+    groups.last.destroy!
+    visit draw_path(draw)
+    click_on 'Select suites'
+    assign_suites(groups[0..1], suites[0..1])
+    expect(page).to have_css('.flash-notice', text: /new draw has been created/)
+  end
+
   def assign_suites(groups, suites)
     groups.each_with_index do |group, i|
       suite = suites[i]
-      select suite.number, from: group.name
+      select suite.number,
+             from: "bulk_suite_selection_form_suite_id_for_#{group.id}"
     end
     click_on 'Assign suites'
   end

--- a/spec/services/draw_results_starter_spec.rb
+++ b/spec/services/draw_results_starter_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DrawResultsStarter do
+  describe '.start' do
+    it 'calls :start on an instance of DrawResultsStarter' do
+      draw = instance_spy('draw')
+      draw_results_starter = mock_draw_results_starter(draw: draw)
+      described_class.start(draw: draw)
+      expect(draw_results_starter).to have_received(:start)
+    end
+  end
+
+  describe '#start' do
+    it 'checks to make sure that the draw is in selection' do
+      draw = instance_spy('draw', suite_selection?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('in the selection phase')
+    end
+    it 'checks to make sure that all groups have suites' do
+      draw = instance_spy('draw', all_groups_have_suites?: false)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('must have suites selected')
+    end
+    it 'updates the status of the draw to results' do
+      draw = instance_spy('draw', validity_stubs(valid: true, update!: true))
+      described_class.start(draw: draw)
+      expect(draw).to have_received(:update!).with(status: 'results')
+    end
+    it 'checks to see if the update works' do
+      draw = instance_spy('draw', validity_stubs(valid: true))
+      allow(draw).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
+      result = described_class.start(draw: draw)
+      expect(result[:msg][:error]).to include('Draw update failed')
+    end
+    it 'returns the updated draw on success' do
+      draw = instance_spy('draw', validity_stubs(valid: true,
+                                                 all_students_grouped?: true))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to eq(draw)
+    end
+    it 'sets a success message' do
+      draw = instance_spy('draw', validity_stubs(valid: true,
+                                                 all_students_grouped?: true))
+      result = described_class.start(draw: draw)
+      expect(result[:msg].keys).to eq([:success])
+    end
+
+    context 'secondary draw creation' do
+      let(:draw) { FactoryGirl.create(:draw_in_selection, groups_count: 2) }
+
+      before do
+        draw.groups.first.destroy!
+        draw.suites.first.update!(group_id: draw.groups.first.id)
+      end
+
+      it 'occurs if necessary' do
+        expect { described_class.start(draw: draw) }.to change(Draw, :count)
+      end
+      it 'transfers the ungrouped students' do
+        expected = draw.ungrouped_students.map(&:id)
+        described_class.start(draw: draw)
+        expect(Draw.last.students.map(&:id)).to match_array(expected)
+      end
+      it 'transfers the unassigned suites' do
+        expected = draw.suites.available.map(&:id)
+        described_class.start(draw: draw)
+        expect(Draw.last.suites.map(&:id)).to match_array(expected)
+      end
+      it 'sets a notice as well as a success message' do
+        result = described_class.start(draw: draw)
+        expect(result[:msg].keys).to match_array(%i(success notice))
+      end
+    end
+
+    it 'sets the object key to nil in the hash on failure' do
+      draw = instance_spy('draw', validity_stubs(valid: false))
+      result = described_class.start(draw: draw)
+      expect(result[:object]).to be_nil
+    end
+  end
+
+  def mock_draw_results_starter(param_hash)
+    instance_spy('draw_results_starter').tap do |draw_results_starter|
+      allow(described_class).to receive(:new).with(param_hash)
+        .and_return(draw_results_starter)
+    end
+  end
+
+  def validity_stubs(valid:, **attrs)
+    { suite_selection?: valid, all_groups_have_suites?: valid }.merge(attrs)
+  end
+end

--- a/spec/services/draw_selection_starter_spec.rb
+++ b/spec/services/draw_selection_starter_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe DrawSelectionStarter do
-  # we may want to extract this into a shared example if we use this pattern
-  # across all of our service objects
   describe '.start' do
-    it 'calls :start on an instance of DrawStarter' do
+    it 'calls :start on an instance of DrawSelectionStarter' do
       draw = instance_spy('draw')
       draw_selection_starter = mock_draw_selection_starter(draw: draw)
       described_class.start(draw: draw)


### PR DESCRIPTION
Resolves #162 
- Add DrawResultsStarter
- Add Draw#ungrouped_students and Draw#all_groups_have_suites?

Blocked on #438 