### PR TITLE
[473] Allow reps to create groups for others

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   def create
     p = group_params.to_h
-    p[:leader_id] = current_user.id unless current_user.admin?
+    p[:leader_id] = current_user.id if current_user.student?
     result = GroupCreator.new(p).create!
     @group = result[:record]
     set_form_data unless result[:object]

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -3,6 +3,10 @@
 # Class for Draw permissions
 class DrawPolicy < ApplicationPolicy
   def show?
+    user.admin? || user.rep? || !record.draft?
+  end
+
+  def index?
     true
   end
 

--- a/app/views/draws/_table.html.erb
+++ b/app/views/draws/_table.html.erb
@@ -11,6 +11,7 @@
   </thead>
   <tbody>
     <% draws.each do |draw| %>
+      <% next unless policy(draw).show? %>
       <tr id="draw-<%= draw.id %>">
         <td data-role="draw-name"><%= link_to draw.name, draw_path(draw) %></td>
         <td data-role="draw-status"><%= draw.status.humanize %></td>

--- a/spec/features/groups/group_creation_spec.rb
+++ b/spec/features/groups/group_creation_spec.rb
@@ -21,6 +21,27 @@ RSpec.feature 'Housing Group Creation' do
     end
   end
 
+  context 'as rep' do
+    let(:draw) do
+      FactoryGirl.create(:draw_with_members, students_count: 3,
+                                             status: 'pre_lottery')
+    end
+    let(:leader) { draw.students.first }
+    let!(:suite) do
+      FactoryGirl.create(:suite_with_rooms, rooms_count: 2, draws: [draw])
+    end
+    before { log_in FactoryGirl.create(:user, role: 'rep') }
+
+    it 'succeeds' do # rubocop:disable RSpec/ExampleLength
+      visit draw_path(draw)
+      click_on 'Add group to draw'
+      create_group(size: suite.size, leader: leader,
+                   members: [draw.students.last])
+      expect(page).to have_css('.group-name',
+                               text: "#{leader.full_name}'s Group")
+    end
+  end
+
   context 'as admin' do
     let(:draw) do
       FactoryGirl.create(:draw_with_members, students_count: 3,
@@ -28,8 +49,7 @@ RSpec.feature 'Housing Group Creation' do
     end
     let(:leader) { draw.students.first }
     let!(:suite) do
-      FactoryGirl.create(:suite_with_rooms, rooms_count: 2,
-                                            draws: [draw])
+      FactoryGirl.create(:suite_with_rooms, rooms_count: 2, draws: [draw])
     end
     before { log_in FactoryGirl.create :admin }
 
@@ -41,12 +61,12 @@ RSpec.feature 'Housing Group Creation' do
       expect(page).to have_css('.group-name',
                                text: "#{leader.full_name}'s Group")
     end
+  end
 
-    def create_group(size:, leader:, members:)
-      select(size, from: 'group_size')
-      select(leader.full_name, from: 'group_leader_id')
-      members.each { |m| check(m.full_name) }
-      click_on 'Create'
-    end
+  def create_group(size:, leader:, members:)
+    select(size, from: 'group_size')
+    select(leader.full_name, from: 'group_leader_id')
+    members.each { |m| check(m.full_name) }
+    click_on 'Create'
   end
 end

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -9,7 +9,14 @@ RSpec.describe DrawPolicy do
   context 'student' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
     permissions :show?, :suite_summary? do
-      it { is_expected.to permit(user, draw) }
+      context 'not draft' do
+        before { allow(draw).to receive(:draft?).and_return(false) }
+        it { is_expected.to permit(user, draw) }
+      end
+      context 'draft' do
+        before { allow(draw).to receive(:draft?).and_return(true) }
+        it { is_expected.not_to permit(user, draw) }
+      end
     end
     permissions :new?, :create?, :destroy?, :edit?, :update?, :activate?,
                 :intent_report?, :filter_intent_report?, :suites_edit?,
@@ -21,7 +28,7 @@ RSpec.describe DrawPolicy do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :index? do
-      it { is_expected.not_to permit(user, Draw) }
+      it { is_expected.to permit(user, Draw) }
     end
 
     permissions :group_actions? do
@@ -66,18 +73,18 @@ RSpec.describe DrawPolicy do
     permissions :show?, :suite_summary? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :suites_edit?, :suites_update? do
-      it { is_expected.to permit(user, draw) }
-    end
-    permissions :create?, :edit?, :update?, :destroy?, :activate?,
-                :intent_report?, :filter_intent_report?, :student_summary?,
-                :students_update?, :oversubscription?, :toggle_size_lock?,
-                :start_lottery?, :lottery_confirmation?, :start_selection?,
-                :bulk_on_campus?, :lock_all_sizes? do
+    permissions :edit?, :update?, :destroy?, :activate?, :intent_report?,
+                :filter_intent_report?, :student_summary?, :students_update?,
+                :oversubscription?, :toggle_size_lock?, :start_lottery?,
+                :lottery_confirmation?, :start_selection?, :bulk_on_campus?,
+                :lock_all_sizes? do
       it { is_expected.not_to permit(user, draw) }
     end
-    permissions :new?, :index? do
+    permissions :new?, :create? do
       it { is_expected.not_to permit(user, Draw) }
+    end
+    permissions :index? do
+      it { is_expected.to permit(user, Draw) }
     end
     permissions :group_actions?, :create_new_group? do
       context 'non-pre-lottery draw' do


### PR DESCRIPTION
Resolves #473
- Also permits Draws#index to everyone
- Also prevent students from viewing draft draws