### PR TITLE
[482] Improve handling of medical suites

### DIFF
--- a/app/controllers/draws_controller.rb
+++ b/app/controllers/draws_controller.rb
@@ -63,8 +63,9 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
   end
 
   def suite_summary
-    @all_sizes = SuiteSizesQuery.new(@draw.suites.available).call
-    @suites_by_size = SuitesBySizeQuery.new(@draw.suites.available).call
+    suites = @draw.suites.available.where(medical: false)
+    @all_sizes = SuiteSizesQuery.new(suites).call
+    @suites_by_size = SuitesBySizeQuery.new(suites).call
     @suites_by_size.default = []
   end
 
@@ -257,12 +258,14 @@ class DrawsController < ApplicationController # rubocop:disable ClassLength
   end
 
   def prepare_suites_edit_data # rubocop:disable AbcSize, MethodLength
-    @suite_sizes ||= SuiteSizesQuery.new(Suite.available).call
+    draw_suites = @draw.suites.available.where(medical: false)
+    all_suites = Suite.available.where(medical: false)
+    @suite_sizes ||= SuiteSizesQuery.new(all_suites).call
     @suites_update ||= DrawSuitesUpdate.new(draw: @draw)
-    base_suites = Suite.available.order(:number)
+    base_suites = all_suites.order(:number)
     empty_suite_hash = @suite_sizes.map { |s| [s, []] }.to_h
     @current_suites = empty_suite_hash.merge(
-      @draw.suites.available.includes(:draws).order(:number).group_by(&:size)
+      draw_suites.includes(:draws).order(:number).group_by(&:size)
     )
     @drawless_suites = empty_suite_hash.merge(
       DrawlessSuitesQuery.new(base_suites).call.group_by(&:size)

--- a/app/views/suites/_summary.html.erb
+++ b/app/views/suites/_summary.html.erb
@@ -19,7 +19,7 @@
           <% suites[size].each do |suite| %>
             <% next if suite.medical && !policy(suite).medical? %>
             <tr id="suite-<%= suite.id %>">
-              <td data-role="suite-number"><%= link_to suite.number, suite_path(suite) %></td>
+              <td data-role="suite-number"><%= link_to suite.number_with_medical, suite_path(suite) %></td>
               <td data-role="suite-singles"><%= suite.singles.count %></td>
               <td data-role="suite-doubles"><%= suite.doubles.count %></td>
               <td data-role="suite-common"><%= suite.common_rooms.count %></td>

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Suite, type: :model do
       change { group.leader.reload.room_id }.from(suite.rooms.first.id).to(nil)
   end
 
+  it 'removes draws if changed to a medical suite' do
+    draw = FactoryGirl.create(:draw)
+    suite = FactoryGirl.create(:suite, draws: [draw])
+    expect { suite.update!(medical: true) }.to \
+      change { suite.draws.to_a }.to([])
+  end
+
   describe '.size_str' do
     it 'raises an argument error if a non-integer is passed' do
       size = instance_spy('string')


### PR DESCRIPTION
Resolves #482
- Remove suites from draws when they are set as medical suites
- Display medical suites with status for admins
- Prevent medical suites from showing up in the draw suite summary and
  draw suites edit form