### PR TITLE
[495] Allow reps to view intent report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 * Add printable group report for draws ([#488](https://github.com/YaleSTC/vesta/issues/488)).
 
+### Changed
+* Reps can now view the intent report but cannot use to change the intents of
+  other students ([#495](https://github.com/YaleSTC/vesta/issues/495)).
+
 ### Removed
 * Remove validation on the number of beds being greater or equal to the number
   of students from draw activation ([#494](https://github.com/YaleSTC/vesta/issues/494)).

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -15,7 +15,7 @@ class DrawPolicy < ApplicationPolicy
   end
 
   def intent_report?
-    edit?
+    user.admin? || user.rep?
   end
 
   def filter_intent_report?

--- a/app/views/draws/intent_report.html.erb
+++ b/app/views/draws/intent_report.html.erb
@@ -7,7 +7,7 @@
     <h3>Filter students</h3>
     <%= simple_form_for @filter, url: intent_report_draw_path(@draw) do |f| %>
       <%= f.input :intents, collection: User.intents.keys, as: :check_boxes,
-                            include_hidden: false, error: false %>
+        include_hidden: false, error: false %>
       <%= f.submit 'Filter' %>
     <% end %>
   </div>
@@ -25,7 +25,11 @@
         <tr class="<%= student.intent %>">
           <td data-role="student-last_name"><%= student.last_name %></td>
           <td data-role="student-first_name"><%= student.first_name %></td>
-          <td class="intent-form" id="intent-form-<%= student.id %>" data-role="student-intent"><%= render 'intent_form', user: student %></td>
+          <% if policy(student).update_intent? %>
+            <td class="intent-form" id="intent-form-<%= student.id %>" data-role="student-intent"><%= render 'intent_form', user: student %></td>
+          <% else %>
+            <td data-role="student-intent"><%= student.intent.humanize %></td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/spec/features/draws/draw_intent_report_spec.rb
+++ b/spec/features/draws/draw_intent_report_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.feature 'Draw intent report' do
@@ -29,6 +30,14 @@ RSpec.feature 'Draw intent report' do
     visit intent_report_draw_path(draw)
     click_on 'Filter'
     expect(page_has_unfiltered_report(page, student, other)).to be_truthy
+  end
+
+  it 'does not display form when rep' do
+    create_student_data(draw: draw, intents: %w(on_campus))
+    log_in(FactoryGirl.create(:student, role: 'rep'))
+    visit draw_path(draw)
+    click_link('View intent report')
+    expect(page).to have_css('td[data-role="student-intent"]')
   end
 
   def create_student_data(draw:, intents: %w(on_campus))

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
-# rubocop:disable RSpec/NestedGroups
+
+# rubocop:disable RSpec/NestedGroups, RSpec/RepeatedExample
+# rubocop:disable RSpec/ScatteredSetup
 require 'rails_helper'
 
 RSpec.describe DrawPolicy do
   subject { described_class }
+
   let(:draw) { FactoryGirl.build_stubbed(:draw) }
 
   context 'student' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'student') }
+
     permissions :show?, :suite_summary? do
       context 'not draft' do
         before { allow(draw).to receive(:draft?).and_return(false) }
@@ -70,14 +74,15 @@ RSpec.describe DrawPolicy do
 
   context 'housing rep' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'rep') }
-    permissions :show?, :suite_summary? do
+
+    permissions :show?, :suite_summary?, :intent_report?,
+                :filter_intent_report? do
       it { is_expected.to permit(user, draw) }
     end
-    permissions :edit?, :update?, :destroy?, :activate?, :intent_report?,
-                :filter_intent_report?, :student_summary?, :students_update?,
-                :oversubscription?, :toggle_size_lock?, :start_lottery?,
-                :lottery_confirmation?, :start_selection?, :bulk_on_campus?,
-                :lock_all_sizes? do
+    permissions :edit?, :update?, :destroy?, :activate?, :student_summary?,
+                :students_update?, :oversubscription?, :toggle_size_lock?,
+                :start_lottery?, :lottery_confirmation?, :start_selection?,
+                :bulk_on_campus?, :lock_all_sizes? do
       it { is_expected.not_to permit(user, draw) }
     end
     permissions :new?, :create? do
@@ -198,6 +203,7 @@ RSpec.describe DrawPolicy do
 
   context 'admin' do
     let(:user) { FactoryGirl.build_stubbed(:user, role: 'admin') }
+
     permissions :show?, :edit?, :update?, :destroy?, :intent_report?,
                 :filter_intent_report?, :suite_summary?, :suites_edit?,
                 :suites_update?, :student_summary?, :students_update?,


### PR DESCRIPTION
Resolves #495
- Intent report not displays the intent change form only if user has
  permission to modify the intent of others (i.e. admins)