### PR TITLE
[513] Destroy pending memberships when a user accepts one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,13 @@ AllCops:
     - 'bin/*'
 Rails:
   Enabled: true
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Rails/Blank:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - 'Rakefile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v0.1.3 - 2017-03-29
+### Fixed
+* Destroy pending memberships on invitation and request acceptance ([#513](https://github.com/YaleSTC/vesta/issues/513)).
+
 ## v0.1.2 - 2017-03-29
 ### Changed
 * Downgrade Ruby to v2.3.1 ([#506](https://github.com/YaleSTC/vesta/issues/506)).
@@ -8,6 +12,7 @@ All notable changes to this project will be documented in this file.
 ## v0.1.1 - 2017-03-29
 ### Fixed
 * Prevent students from performing suite selection ([#501](https://github.com/YaleSTC/vesta/issues/501)).
+
 
 ### Changed
 * Downgrade Ruby to v2.3.3 ([#493](https://github.com/YaleSTC/vesta/issues/493)).


### PR DESCRIPTION
Resolves #513
  - Also disables rubocop Lint/AmbiguousBlockAssociation