### PR TITLE
[535] Ensure that HTTP traffic is properly redirected to HTTPS

### DIFF
--- a/.ebextensions/03_https_only.config
+++ b/.ebextensions/03_https_only.config
@@ -1,0 +1,96 @@
+# Sets up nginx rewrite rules to redirect HTTP traffic to HTTPS
+# https://github.com/awslabs/elastic-beanstalk-docs/blob/61b520eca068e81002d16660826805fec6ba7fd8/configuration-files/aws-provided/security-configuration/https-redirect-ruby-puma.config
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file configures Nginx for Ruby Puma environments to redirect HTTP requests
+#### on port 80 to HTTPS on port 443 after you have configured your environment to support HTTPS
+#### connections:
+####
+#### Configuring Your Elastic Beanstalk Environment's Load Balancer to Terminate HTTPS:
+####  http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html
+####
+#### Terminating HTTPS on EC2 Instances Running Ruby Puma:
+####  http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/https-singleinstance-ruby.html#Puma
+###################################################################################################
+
+files:
+   "/opt/elasticbeanstalk/support/conf/webapp_healthd.conf":
+     owner: root
+     group: root
+     mode: "000644"
+     content: |
+       upstream my_app {
+         server unix:///var/run/puma/my_app.sock;
+       }
+
+       log_format healthd '$msec"$uri"'
+                       '$status"$request_time"$upstream_response_time"'
+                       '$http_x_forwarded_for';
+
+       server {
+         listen 80;
+         server_name _ localhost; # need to listen to localhost for worker tier
+
+         if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+           set $year $1;
+           set $month $2;
+           set $day $3;
+           set $hour $4;
+         }
+
+         access_log  /var/log/nginx/access.log  main;
+         access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+
+         location / {
+           set $redirect 0;
+           if ($http_x_forwarded_proto != "https") {
+             set $redirect 1;
+           }
+           if ($http_user_agent ~* "ELB-HealthChecker") {
+             set $redirect 0;
+           }
+           if ($redirect = 1) {
+             return 301 https://$host$request_uri;
+           }
+           proxy_pass http://my_app; # match the name of upstream directive which is defined above
+           proxy_set_header Host $host;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         }
+
+         location /assets {
+           alias /var/app/current/public/assets;
+           gzip_static on;
+           gzip on;
+           expires max;
+           add_header Cache-Control public;
+         }
+
+         location /public {
+           alias /var/app/current/public;
+           gzip_static on;
+           gzip on;
+           expires max;
+           add_header Cache-Control public;
+         }
+       }
+
+# Commands 97 and 98 are workarounds to get the redirect to actually happen
+container_commands:
+  97_backup_nginx_conf:
+    command: "mv -n /opt/elasticbeanstalk/support/conf/webapp.conf{,.bak}"
+  98_move_healthd_conf:
+    command: "mv /opt/elasticbeanstalk/support/conf/webapp{_healthd,}.conf"
+  99_restart_nginx:
+    command: "service nginx restart || service nginx start"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Added
+* Add HTTP --> HTTPS redirect for all traffic when deploying to AWS Elastic
+  Beanstalk ([#535](https://github.com/YaleSTC/vesta/issues/535)).
 
 ## v0.1.5 - 2017-03-30
 ### Fixed


### PR DESCRIPTION
Resolves #535
- This is specifically for AWS Elastic Beanstalk deployments

Trying this again. Tested as working with a test instance.