### PR TITLE
[555] Fix broken group confirmation e-mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Fixed
+* Fix broken group confirmation e-mails ([#555](https://github.com/YaleSTC/vesta/issues/555)).
 
 ## v0.1.7 - 2017-04-05
 ### Added

--- a/app/mailers/student_mailer.rb
+++ b/app/mailers/student_mailer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # Mailer class for student e-mails
 class StudentMailer < ApplicationMailer
   # Send initial invitation to students in a draw
@@ -39,13 +39,14 @@ class StudentMailer < ApplicationMailer
   # @param user [User] the group leader to send the notification to
   # @param college [College] the college to pull settings from
   def finalizing_notification(user:, college: nil)
+    return unless user.group
     determine_college(college)
     @user = user
-    @finalizing_path = if user.group.draw
-                         draw_groups_url(user.group)
-                       else
-                         groups_url(user.group)
-                       end
+    @finalizing_url = if user.group.draw
+                        draw_group_url(user.draw, user.group)
+                      else
+                        group_url(user.group)
+                      end
     mail(to: @user.email, subject: 'Confirm your housing group')
   end
 

--- a/app/views/student_mailer/finalizing_notification.html.erb
+++ b/app/views/student_mailer/finalizing_notification.html.erb
@@ -5,7 +5,7 @@
   </head>
   <body>
     <p>Hi <%= @user.name %>,</p>
-    <p>Your group is now in the process of being confirmed. Please go to <%= "#{@college.site_url}#{@finalizing_path}" %> to confirm your membership.</p>
+    <p>Your group is now in the process of being confirmed. Please go to <a href="<%= @finalizing_url %>"><%= @finalizing_url %></a> to confirm your membership.</p>
     <p>Please e-mail <%= @college.admin_email %> if you have any questions.</p>
     <p>Sincerely,<br /><%= @college.dean %></p>
   </body>

--- a/app/views/student_mailer/finalizing_notification.text.erb
+++ b/app/views/student_mailer/finalizing_notification.text.erb
@@ -1,5 +1,5 @@
 Hi <%= @user.name %>,
-Your group is now in the process of being confirmed. Please go to <%= "#{@college.site_url}#{@finalizing_path}" %> to confirm your membership.
+Your group is now in the process of being confirmed. Please go to <%= @finalizing_url %> to confirm your membership.
 Please e-mail <%= @college.admin_email %> if you have any questions.
 Sincerely,
 <%= @college.dean %>


### PR DESCRIPTION
Resolves #555
- Also add guard clause to StudentMailer#finalizing_notification in case user doesn't belong to a group