### PR TITLE
[585] Allow admins to do group CRUD as long as the draw is not a draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 * Fix broken group confirmation e-mails ([#555](https://github.com/YaleSTC/vesta/issues/555)).
 * Fix 404 page title ([#579](https://github.com/YaleSTC/vesta/issues/579)).
 * Permit students to view the draw page during suite selection ([#584](https://github.com/YaleSTC/vesta/issues/584)).
+* Allow admins to do group CRUD regardless of draw state([#585](https://github.com/YaleSTC/vesta/issues/585)).
 
 ### Added
 * Add intent counts to the intent report ([#539](https://github.com/YaleSTC/vesta/issues/539)).

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -21,9 +21,7 @@ class GroupsController < ApplicationController
                    .group_by(&:size).sort.to_h
   end
 
-  def new
-    authorize @draw, :create_new_group?
-  end
+  def new; end
 
   def create
     p = group_params.to_h

--- a/app/policies/draw_policy.rb
+++ b/app/policies/draw_policy.rb
@@ -46,10 +46,6 @@ class DrawPolicy < ApplicationPolicy
     (user.admin? && !record.draft?) || record.pre_lottery?
   end
 
-  def create_new_group?
-    record.pre_lottery?
-  end
-
   def intent_actions?
     user.admin? || user.rep?
   end

--- a/app/views/draws/show.html.erb
+++ b/app/views/draws/show.html.erb
@@ -13,7 +13,7 @@
         <% if policy(@draw).lottery? %>
           <li><%= link_to 'Assign lottery numbers', lottery_draw_path(@draw), class: 'button' %></li>
         <% end %>
-        <% if policy(Group).new? && policy(@draw).create_new_group? %>
+        <% if policy(Group).new? && policy(@draw).group_actions? %>
           <li><%= link_to 'Add group to draw', new_draw_group_path(@draw), class: 'button secondary' %></li>
         <% end %>
         <% if @draw.oversubscribed? && policy(@draw).oversubscription? %>

--- a/spec/policies/draw_policy_spec.rb
+++ b/spec/policies/draw_policy_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe DrawPolicy do
     permissions :index? do
       it { is_expected.to permit(user, Draw) }
     end
-    permissions :group_actions?, :create_new_group? do
+    permissions :group_actions? do
       context 'non-pre-lottery draw' do
         before { allow(draw).to receive(:pre_lottery?).and_return(false) }
         it { is_expected.not_to permit(user, draw) }
@@ -300,8 +300,7 @@ RSpec.describe DrawPolicy do
       end
     end
 
-    permissions :start_lottery?, :lottery_confirmation?, :oversubscription?,
-                :create_new_group? do
+    permissions :start_lottery?, :lottery_confirmation?, :oversubscription? do
       context 'when draw is pre_lottery' do
         before { allow(draw).to receive(:pre_lottery?).and_return(true) }
         it { is_expected.to permit(user, draw) }

--- a/spec/services/updaters/group_updater_spec.rb
+++ b/spec/services/updaters/group_updater_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GroupUpdater do
@@ -31,6 +32,17 @@ RSpec.describe GroupUpdater do
                          to_h: { 'member_ids' => [to_add.id.to_s] })
         described_class.update(group: group, params: p)
         expect(to_add.reload.intent).to eq('on_campus')
+      end
+    end
+
+    context 'size is locked' do
+      it 'deletes the empty size key from the params' do
+        group = FactoryGirl.create(:full_group, size: 2)
+        p = instance_spy('ActionController::Parameters',
+                         to_h: { 'leader_id' => group.members.last.id.to_s,
+                                 'size' => '' })
+        result = described_class.update(group: group, params: p)
+        expect(result[:msg]).to have_key(:success)
       end
     end
 


### PR DESCRIPTION
Resolves #585
  - Removes DrawPolicy#create_new_group?