### PR TITLE
remove an assigned suite from all draws

### DIFF
--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -29,6 +29,7 @@ class Suite < ApplicationRecord
 
   before_save :clear_room_ids, ->(s) { s.group_id_changed? }
   before_save :remove_draw_from_medical_suites, ->(s) { s.medical_changed? }
+  before_save :remove_other_draws_after_assigned, ->(s) { s.group_id_changed?}
 
   # Return the equivalent string for a given suite size
   #
@@ -113,6 +114,13 @@ class Suite < ApplicationRecord
     id_array = [group_id, group_id_was].compact
     members = User.includes(:group).where(groups: { id: id_array })
     ActiveRecord::Base.transaction { members.update(room_id: nil) }
+  rescue
+    throw(:abort)
+  end
+
+  def remove_other_draws_after_assigned
+    return if available?
+    ActiveRecord::Base.transaction { draws.delete_all }
   rescue
     throw(:abort)
   end

--- a/app/models/suite.rb
+++ b/app/models/suite.rb
@@ -29,7 +29,7 @@ class Suite < ApplicationRecord
 
   before_save :clear_room_ids, ->(s) { s.group_id_changed? }
   before_save :remove_draw_from_medical_suites, ->(s) { s.medical_changed? }
-  before_save :remove_other_draws_after_assigned, ->(s) { s.group_id_changed?}
+  before_save :remove_other_draws_after_assigned, ->(s) { s.group_id_changed? }
 
   # Return the equivalent string for a given suite size
   #

--- a/spec/models/suite_spec.rb
+++ b/spec/models/suite_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Suite, type: :model do
       change { group.leader.reload.room_id }.from(suite.rooms.first.id).to(nil)
   end
 
+  it 'removes other draws if already assigned' do
+    draw1 = FactoryGirl.create(:draw)
+    draw2 = FactoryGirl.create(:draw)
+    group = FactoryGirl.create(:locked_group, size: 1)
+    suite = FactoryGirl.create(:suite_with_rooms, draws: [draw1, draw2])
+    group.leader.update!(room_id: suite.rooms.first.id, draw: draw1)
+    expect { suite.update!(group_id: group.id) }.to \
+      change { suite.draws.to_a }.to([])
+  end
+
   it 'removes draws if changed to a medical suite' do
     draw = FactoryGirl.create(:draw)
     suite = FactoryGirl.create(:suite, draws: [draw])


### PR DESCRIPTION
It might be better (as suggested in the issue description) to keep the suite in the draw of the group that it is assigned to; removing all the draws means we cannot view all the suites after suites are assigned. I still haven't figure out how to do it yet so, for now, all draws are removed.

Would be greate to know if I'm heading in the right direction though!